### PR TITLE
165-Feature grant and revoke timeout perm to tourney admins on start and end tourney

### DIFF
--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -1400,7 +1400,9 @@ def setup_tourney_commands(bot: commands.Bot):
                 updated_perms.update(moderate_members=False)
                 await tourney_admin_role.edit(permissions=updated_perms)
             except Exception as e:
-                print(f"Failed to revoke timeout permission from Tourney Admin role: {e}")
+                print(
+                    f"Failed to revoke timeout permission from Tourney Admin role: {e}"
+                )
 
         session = await get_active_tourney_session()
         if session:


### PR DESCRIPTION
### Changes                                                                                                                                                                                                                                                          
- Automatically grants Tourney Admin role the Timeout Members permission when !starttourney is run                                                                       
- Automatically revokes the permission when !endtourney is run                                                                                                           
- Permission updates are wrapped in try/except so tourney phase changes still complete if the update fails                                                               
                                                                                                                                                                           
Closes #165    