### PR TITLE
171-Feature add autodetection of team if match number is wrong

### DIFF
--- a/features/tourney/matcherino.py
+++ b/features/tourney/matcherino.py
@@ -23,6 +23,15 @@ session.headers.update(HEADERS)
 # Fuzzy match: ratio >= this → accept (minor typos). Below → team name mismatch warning.
 TEAM_NAME_SIMILARITY_THRESHOLD = 0.60
 
+# Per-tourney cache of bracket team names (teams don't change mid-tourney).
+# Keyed by bounty_id → list of {"name": str, "entrant_id": int}.
+_bracket_teams_cache: dict[str, list[dict]] = {}
+
+
+def clear_bracket_teams_cache():
+    """Clear cached team lists. Call when a tourney session ends."""
+    _bracket_teams_cache.clear()
+
 
 def _normalize_for_compare(s: str) -> str:
     """Normalize string for similarity: strip, lower, collapse whitespace."""
@@ -74,6 +83,129 @@ def _team_name_matches(
 
     matches = best_ratio >= TEAM_NAME_SIMILARITY_THRESHOLD
     return matches, best_ratio, best_name
+
+
+def find_match_by_team_name(url: str, topic_team_name: str) -> dict:
+    """
+    Fallback when no valid match number is provided: fuzzy-match the team
+    name against all bracket entrants, then locate their current match.
+
+    Returns dict with:
+      - status: "found" | "no_match"  (or "error" key on failure)
+      - match_number: visual match number (if found)
+      - matched_team: bracket team name (if found)
+      - ratio: similarity ratio (if found)
+    """
+    id_match = re.search(r"tournaments/(\d+)", url)
+    if not id_match:
+        return {"error": "Invalid Matcherino URL."}
+
+    topic_n = _normalize_for_compare(topic_team_name)
+    if not topic_n:
+        return {"error": "No team name provided for lookup."}
+
+    bounty_id = id_match.group(1)
+    api_url = f"https://api.matcherino.com/__api/brackets?bountyId={bounty_id}&id=0&isAdmin=false"
+
+    try:
+        response = session.get(api_url, timeout=10)
+        if response.status_code != 200:
+            return {"error": f"Failed to fetch API. Status: {response.status_code}"}
+        data = response.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"Matcherino connection failed: {str(e)}"}
+    except Exception as e:
+        return {"error": f"Parsing failed: {str(e)}"}
+
+    try:
+        bracket_data = data["body"][0]
+        raw_matches = bracket_data.get("matches", [])
+        raw_entrants = bracket_data.get("entrants", [])
+
+        if not raw_matches:
+            return {"error": "Bracket is empty."}
+
+        # Build entrant map (id → name)
+        entrant_map: dict[int, str] = {}
+        for e in raw_entrants:
+            e_id = e.get("id")
+            name = (
+                e.get("name")
+                or (e.get("team") and e["team"].get("name"))
+                or "Unknown Team"
+            )
+            entrant_map[e_id] = name
+
+        # Cache team list per tournament (teams don't change mid-tourney)
+        if bounty_id not in _bracket_teams_cache:
+            _bracket_teams_cache[bounty_id] = [
+                {"name": name, "entrant_id": eid}
+                for eid, name in entrant_map.items()
+                if eid > 1 and name.upper() not in ("TBD", "BYE", "UNKNOWN TEAM")
+            ]
+
+        # Fuzzy match against cached teams
+        best_ratio = 0.0
+        best_team_name: str | None = None
+        best_entrant_id: int | None = None
+        for team in _bracket_teams_cache[bounty_id]:
+            team_n = _normalize_for_compare(team["name"])
+            ratio = difflib.SequenceMatcher(None, topic_n, team_n).ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best_team_name = team["name"]
+                best_entrant_id = team["entrant_id"]
+
+        if best_ratio < TEAM_NAME_SIMILARITY_THRESHOLD:
+            return {
+                "status": "no_match",
+                "best_ratio": best_ratio,
+                "best_team": best_team_name,
+            }
+
+        # Team found — locate their current visual match number
+        visible_matches = []
+        for m in raw_matches:
+            e_a = m.get("entrantA", {}).get("entrantId", 0)
+            e_b = m.get("entrantB", {}).get("entrantId", 0)
+            if e_a != 1 and e_b != 1:
+                visible_matches.append(m)
+
+        visible_matches.sort(key=lambda x: x.get("matchNum", 9999))
+
+        # Collect all matches this team participates in
+        team_matches: list[tuple[int, dict]] = []
+        for i, m in enumerate(visible_matches, start=1):
+            e_a = m.get("entrantA", {}).get("entrantId", 0)
+            e_b = m.get("entrantB", {}).get("entrantId", 0)
+            if best_entrant_id in (e_a, e_b):
+                team_matches.append((i, m))
+
+        if not team_matches:
+            return {
+                "status": "no_match",
+                "best_ratio": best_ratio,
+                "best_team": best_team_name,
+            }
+
+        # Prefer the latest non-closed match; fall back to last match overall
+        finished = ("closed", "completed", "complete", "done")
+        latest_active = None
+        for visual_num, m in team_matches:
+            if str(m.get("status", "")).lower() not in finished:
+                latest_active = (visual_num, m)
+
+        resolved_visual_num = latest_active[0] if latest_active else team_matches[-1][0]
+
+        return {
+            "status": "found",
+            "match_number": resolved_visual_num,
+            "matched_team": best_team_name,
+            "ratio": best_ratio,
+        }
+
+    except Exception as e:
+        return {"error": f"An unexpected error occurred: {e}"}
 
 
 def fetch_ticket_context(

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -8,6 +8,8 @@ from .matcherino import (
     fetch_ticket_context,
     fetch_payout_report,
     fetch_bracket_progress,
+    find_match_by_team_name,
+    clear_bracket_teams_cache,
 )
 
 from database.mongo import (
@@ -729,15 +731,56 @@ class QueueDashboard(commands.Cog):
                 if team_res:
                     topic_team_name = team_res.group(1).strip() or None
 
+            # Fallback: no valid match number → resolve from team name
             if match_num is None:
-                continue
+                if not topic_team_name:
+                    continue
+                lookup = find_match_by_team_name(bracket_url, topic_team_name)
+                if lookup.get("status") != "found":
+                    continue
+                match_num = lookup["match_number"]
+                # Persist resolved match number in topic so future refreshes skip the lookup
+                try:
+                    updated_topic = re.sub(
+                        r"bracket:[^|]*",
+                        f"bracket:{match_num}",
+                        channel.topic,
+                    )
+                    await channel.edit(topic=updated_topic)
+                except Exception:
+                    pass
 
             # 4. Fetch Fresh Match Data (with topic team for fuzzy mismatch check)
             data = fetch_ticket_context(
                 bracket_url, match_num, topic_team_name=topic_team_name
             )
             if data.get("status") != "success":
-                continue
+                # Match number not in bracket — try team name fallback
+                if topic_team_name:
+                    lookup = find_match_by_team_name(bracket_url, topic_team_name)
+                    if lookup.get("status") == "found":
+                        match_num = lookup["match_number"]
+                        data = fetch_ticket_context(
+                            bracket_url, match_num, topic_team_name=topic_team_name
+                        )
+                        if data.get("status") == "success":
+                            # Persist corrected match number in topic
+                            if channel.topic:
+                                try:
+                                    updated_topic = re.sub(
+                                        r"bracket:[^|]*",
+                                        f"bracket:{match_num}",
+                                        channel.topic,
+                                    )
+                                    await channel.edit(topic=updated_topic)
+                                except Exception:
+                                    pass
+                        else:
+                            continue
+                    else:
+                        continue
+                else:
+                    continue
 
             # 5. Construct the Live Embed with Relative Timestamp
             now_ts = int(discord.utils.utcnow().timestamp())
@@ -773,7 +816,69 @@ class QueueDashboard(commands.Cog):
                 inline=True,
             )
 
-            # For mismatches, keep the warning simple.
+            # Mismatch: team name doesn't match either team — try to auto-correct
+            if is_mismatch and topic_team_name:
+                lookup = find_match_by_team_name(bracket_url, topic_team_name)
+                if lookup.get("status") == "found":
+                    resolved_num = lookup["match_number"]
+                    data = fetch_ticket_context(
+                        bracket_url, resolved_num, topic_team_name=topic_team_name
+                    )
+                    if data.get("status") == "success":
+                        match_num = resolved_num
+                        is_mismatch = data.get("team_name_mismatch", False)
+                        best_match_team = data.get("team_name_best_match")
+
+                        # Update topic with corrected match number
+                        if channel.topic:
+                            try:
+                                updated_topic = re.sub(
+                                    r"bracket:[^|]*",
+                                    f"bracket:{resolved_num}",
+                                    channel.topic,
+                                )
+                                await channel.edit(topic=updated_topic)
+                            except Exception:
+                                pass
+
+                        # Rebuild embed with corrected data
+                        now_ts = int(discord.utils.utcnow().timestamp())
+                        embed = discord.Embed(
+                            title=f"📊 Live Match Update: Match #{resolved_num}",
+                            description=f"**Last Update:** <t:{now_ts}:R>",
+                            color=discord.Color.red()
+                            if is_mismatch
+                            else discord.Color.gold(),
+                        )
+                        embed.add_field(
+                            name="Match Status",
+                            value=f"`{data['match_status'].upper()}`",
+                            inline=True,
+                        )
+                        embed.add_field(name="\u200b", value="\u200b", inline=True)
+                        embed.add_field(name="\u200b", value="\u200b", inline=True)
+
+                        team_a, team_b = data["team_a"], data["team_b"]
+                        p_a = (
+                            "\n".join([f"• {p}" for p in team_a["players"]])
+                            or "• *No players*"
+                        )
+                        p_b = (
+                            "\n".join([f"• {p}" for p in team_b["players"]])
+                            or "• *No players*"
+                        )
+                        embed.add_field(
+                            name=f"🔵 {team_a['name']} ({team_a['score']})",
+                            value=f"**Roster:**\n{p_a}",
+                            inline=True,
+                        )
+                        embed.add_field(name="⚔️", value="\u200b", inline=True)
+                        embed.add_field(
+                            name=f"🔴 {team_b['name']} ({team_b['score']})",
+                            value=f"**Roster:**\n{p_b}",
+                            inline=True,
+                        )
+
             if is_mismatch:
                 warning_text = "The team name in this ticket does not closely match either team in the bracket for this match."
                 if topic_team_name:
@@ -1474,6 +1579,7 @@ def setup_tourney_commands(bot: commands.Bot):
 
             # 4. Close Session in DB
             await end_tourney_session(session["_id"])
+            clear_bracket_teams_cache()
         # ------------------------------
 
         await unlock_command(ctx)

--- a/features/tourney/tourney_views.py
+++ b/features/tourney/tourney_views.py
@@ -3,7 +3,7 @@ from database.mongo import (
     get_active_tourney_session,
     update_tourney_queue,
 )
-from features.tourney.matcherino import fetch_ticket_context
+from features.tourney.matcherino import fetch_ticket_context, find_match_by_team_name
 
 
 class TourneyReportModal(discord.ui.Modal, title="Tourney Support"):
@@ -112,19 +112,134 @@ class TourneyReportModal(discord.ui.Modal, title="Tourney Support"):
                             inline=True,
                         )
 
-                        if is_mismatch:
+                        if is_mismatch and topic_team:
+                            # Team doesn't match this match — try to find their real match
+                            lookup = find_match_by_team_name(bracket_url, topic_team)
+                            if lookup.get("status") == "found":
+                                resolved_num = lookup["match_number"]
+                                match_data = fetch_ticket_context(
+                                    bracket_url,
+                                    resolved_num,
+                                    topic_team_name=topic_team,
+                                )
+                                match_num = resolved_num
+
+                                # Rebuild embed with corrected match
+                                now_ts = int(discord.utils.utcnow().timestamp())
+                                is_mismatch = match_data.get(
+                                    "team_name_mismatch", False
+                                )
+                                best_match_team = match_data.get("team_name_best_match")
+                                embed = discord.Embed(
+                                    title=f"📊 Live Match Update: Match #{resolved_num}",
+                                    description=(
+                                        f"**Last Update:** <t:{now_ts}:R>\n"
+                                        f"*Match auto-corrected from #{int(self.bracket.value.strip())} "
+                                        f"→ #{resolved_num} via team name "
+                                        f"({lookup['ratio']:.0%} match to "
+                                        f"`{lookup['matched_team']}`)*"
+                                    ),
+                                    color=discord.Color.red()
+                                    if is_mismatch
+                                    else discord.Color.gold(),
+                                )
+
+                                if match_data.get("status") == "success":
+                                    embed.add_field(
+                                        name="Match Status",
+                                        value=f"`{match_data['match_status'].upper()}`",
+                                        inline=True,
+                                    )
+                                    embed.add_field(
+                                        name="\u200b",
+                                        value="\u200b",
+                                        inline=True,
+                                    )
+                                    embed.add_field(
+                                        name="\u200b",
+                                        value="\u200b",
+                                        inline=True,
+                                    )
+
+                                    team_a = match_data["team_a"]
+                                    team_b = match_data["team_b"]
+                                    players_a = (
+                                        "\n".join([f"• {p}" for p in team_a["players"]])
+                                        or "• *No players found*"
+                                    )
+                                    players_b = (
+                                        "\n".join([f"• {p}" for p in team_b["players"]])
+                                        or "• *No players found*"
+                                    )
+
+                                    embed.add_field(
+                                        name=f"🔵 {team_a['name']} ({team_a['score']})",
+                                        value=f"**Roster:**\n{players_a}",
+                                        inline=True,
+                                    )
+                                    embed.add_field(
+                                        name="⚔️",
+                                        value="\u200b",
+                                        inline=True,
+                                    )
+                                    embed.add_field(
+                                        name=f"🔴 {team_b['name']} ({team_b['score']})",
+                                        value=f"**Roster:**\n{players_b}",
+                                        inline=True,
+                                    )
+
+                                    if topic_team and best_match_team:
+                                        embed.add_field(
+                                            name="Detected Team",
+                                            value=f"```\n{best_match_team}\n```",
+                                            inline=False,
+                                        )
+                                else:
+                                    embed.color = discord.Color.red()
+                                    embed.description = f"⚠️ **Could not fetch match data:** {match_data.get('error')}"
+
+                                # Update topic with corrected match number
+                                if (
+                                    isinstance(new_channel, discord.TextChannel)
+                                    and new_channel.topic
+                                ):
+                                    import re as _re
+
+                                    updated_topic = _re.sub(
+                                        r"bracket:[^|]*",
+                                        f"bracket:{resolved_num}",
+                                        new_channel.topic,
+                                    )
+                                    try:
+                                        await new_channel.edit(topic=updated_topic)
+                                    except Exception:
+                                        pass
+                            else:
+                                # Fallback lookup failed — show original mismatch warning
+                                warning_text = "The team name for this ticket does not closely match either team in the bracket for this match."
+                                if topic_team:
+                                    warning_text += f"\nTeam entered: `{topic_team}`"
+                                warning_text += (
+                                    "\nStaff can correct with `/set-ticket-match`."
+                                )
+                                embed.add_field(
+                                    name="⚠️ Team name / Match number Mismatch",
+                                    value=warning_text,
+                                    inline=False,
+                                )
+
+                        elif is_mismatch:
+                            # Mismatch but no team name to look up
                             warning_text = "The team name for this ticket does not closely match either team in the bracket for this match."
-                            if topic_team:
-                                warning_text += f"\nTeam entered: `{topic_team}`"
                             warning_text += (
                                 "\nStaff can correct with `/set-ticket-match`."
                             )
-
                             embed.add_field(
                                 name="⚠️ Team name / Match number Mismatch",
                                 value=warning_text,
                                 inline=False,
                             )
+
                         elif topic_team and best_match_team:
                             embed.add_field(
                                 name="Detected Team",
@@ -133,15 +248,232 @@ class TourneyReportModal(discord.ui.Modal, title="Tourney Support"):
                             )
 
                     else:
-                        embed.color = discord.Color.red()
-                        embed.description = f"⚠️ **Could not fetch match data:** {match_data.get('error')}"
+                        # Match number not found in bracket — try team name fallback
+                        fallback_resolved = False
+                        if topic_team:
+                            lookup = find_match_by_team_name(bracket_url, topic_team)
+                            if lookup.get("status") == "found":
+                                resolved_num = lookup["match_number"]
+                                match_data = fetch_ticket_context(
+                                    bracket_url,
+                                    resolved_num,
+                                    topic_team_name=topic_team,
+                                )
+                                if match_data.get("status") == "success":
+                                    fallback_resolved = True
+                                    match_num = resolved_num
+                                    is_mismatch = match_data.get(
+                                        "team_name_mismatch", False
+                                    )
+                                    best_match_team = match_data.get(
+                                        "team_name_best_match"
+                                    )
+                                    now_ts = int(discord.utils.utcnow().timestamp())
+                                    embed = discord.Embed(
+                                        title=f"📊 Live Match Update: Match #{resolved_num}",
+                                        description=(
+                                            f"**Last Update:** <t:{now_ts}:R>\n"
+                                            f"*Match #{int(self.bracket.value.strip())} not found — "
+                                            f"auto-corrected to #{resolved_num} via team name "
+                                            f"({lookup['ratio']:.0%} match to "
+                                            f"`{lookup['matched_team']}`)*"
+                                        ),
+                                        color=discord.Color.red()
+                                        if is_mismatch
+                                        else discord.Color.gold(),
+                                    )
+                                    embed.add_field(
+                                        name="Match Status",
+                                        value=f"`{match_data['match_status'].upper()}`",
+                                        inline=True,
+                                    )
+                                    embed.add_field(
+                                        name="\u200b",
+                                        value="\u200b",
+                                        inline=True,
+                                    )
+                                    embed.add_field(
+                                        name="\u200b",
+                                        value="\u200b",
+                                        inline=True,
+                                    )
+
+                                    team_a = match_data["team_a"]
+                                    team_b = match_data["team_b"]
+                                    players_a = (
+                                        "\n".join([f"• {p}" for p in team_a["players"]])
+                                        or "• *No players found*"
+                                    )
+                                    players_b = (
+                                        "\n".join([f"• {p}" for p in team_b["players"]])
+                                        or "• *No players found*"
+                                    )
+                                    embed.add_field(
+                                        name=f"🔵 {team_a['name']} ({team_a['score']})",
+                                        value=f"**Roster:**\n{players_a}",
+                                        inline=True,
+                                    )
+                                    embed.add_field(
+                                        name="⚔️",
+                                        value="\u200b",
+                                        inline=True,
+                                    )
+                                    embed.add_field(
+                                        name=f"🔴 {team_b['name']} ({team_b['score']})",
+                                        value=f"**Roster:**\n{players_b}",
+                                        inline=True,
+                                    )
+
+                                    if topic_team and best_match_team:
+                                        embed.add_field(
+                                            name="Detected Team",
+                                            value=f"```\n{best_match_team}\n```",
+                                            inline=False,
+                                        )
+
+                                    # Update topic with corrected match number
+                                    if (
+                                        isinstance(new_channel, discord.TextChannel)
+                                        and new_channel.topic
+                                    ):
+                                        import re as _re
+
+                                        updated_topic = _re.sub(
+                                            r"bracket:[^|]*",
+                                            f"bracket:{resolved_num}",
+                                            new_channel.topic,
+                                        )
+                                        try:
+                                            await new_channel.edit(topic=updated_topic)
+                                        except Exception:
+                                            pass
+
+                        if not fallback_resolved:
+                            embed.color = discord.Color.red()
+                            embed.description = f"⚠️ **Could not fetch match data:** {match_data.get('error')}"
 
                     embed.set_footer(text=f"Matcherino ID: {m_id}")
                     await new_channel.send(embed=embed)
 
                 except ValueError:
-                    # User didn't enter a valid integer for the match number
-                    pass
+                    # User didn't enter a valid match number — fallback to team name lookup
+                    topic_team = (self.team_name.value or "").strip()
+                    if topic_team:
+                        lookup = find_match_by_team_name(bracket_url, topic_team)
+
+                        if lookup.get("status") == "found":
+                            # Resolved a match number from team name — fetch full context
+                            resolved_num = lookup["match_number"]
+                            match_data = fetch_ticket_context(
+                                bracket_url,
+                                resolved_num,
+                                topic_team_name=topic_team,
+                            )
+
+                            now_ts = int(discord.utils.utcnow().timestamp())
+                            is_mismatch = match_data.get("team_name_mismatch", False)
+                            best_match_team = match_data.get("team_name_best_match")
+                            embed = discord.Embed(
+                                title=f"📊 Live Match Update: Match #{resolved_num}",
+                                description=(
+                                    f"**Last Update:** <t:{now_ts}:R>\n"
+                                    f"*Match auto-detected from team name "
+                                    f"({lookup['ratio']:.0%} match to "
+                                    f"`{lookup['matched_team']}`)*"
+                                ),
+                                color=discord.Color.red()
+                                if is_mismatch
+                                else discord.Color.gold(),
+                            )
+
+                            if match_data.get("status") == "success":
+                                embed.add_field(
+                                    name="Match Status",
+                                    value=f"`{match_data['match_status'].upper()}`",
+                                    inline=True,
+                                )
+                                embed.add_field(
+                                    name="\u200b", value="\u200b", inline=True
+                                )
+                                embed.add_field(
+                                    name="\u200b", value="\u200b", inline=True
+                                )
+
+                                team_a = match_data["team_a"]
+                                team_b = match_data["team_b"]
+
+                                players_a = (
+                                    "\n".join([f"• {p}" for p in team_a["players"]])
+                                    or "• *No players found*"
+                                )
+                                players_b = (
+                                    "\n".join([f"• {p}" for p in team_b["players"]])
+                                    or "• *No players found*"
+                                )
+
+                                embed.add_field(
+                                    name=f"🔵 {team_a['name']} ({team_a['score']})",
+                                    value=f"**Roster:**\n{players_a}",
+                                    inline=True,
+                                )
+                                embed.add_field(name="⚔️", value="\u200b", inline=True)
+                                embed.add_field(
+                                    name=f"🔴 {team_b['name']} ({team_b['score']})",
+                                    value=f"**Roster:**\n{players_b}",
+                                    inline=True,
+                                )
+
+                                if topic_team and best_match_team:
+                                    embed.add_field(
+                                        name="Detected Team",
+                                        value=f"```\n{best_match_team}\n```",
+                                        inline=False,
+                                    )
+                            else:
+                                embed.color = discord.Color.red()
+                                embed.description = f"⚠️ **Could not fetch match data:** {match_data.get('error')}"
+
+                            embed.set_footer(text=f"Matcherino ID: {m_id}")
+
+                            # Update topic with resolved match number
+                            if (
+                                isinstance(new_channel, discord.TextChannel)
+                                and new_channel.topic
+                            ):
+                                import re as _re
+
+                                updated_topic = _re.sub(
+                                    r"bracket:[^|]*",
+                                    f"bracket:{resolved_num}",
+                                    new_channel.topic,
+                                )
+                                try:
+                                    await new_channel.edit(topic=updated_topic)
+                                except Exception:
+                                    pass
+
+                            await new_channel.send(embed=embed)
+
+                        else:
+                            # No match found — flag for staff
+                            embed = discord.Embed(
+                                title="⚠️ Team Not Found in Bracket",
+                                description=(
+                                    f"Could not auto-detect a match for team `{topic_team}` "
+                                    f"in the Matcherino bracket.\n\n"
+                                    f"**Staff:** Please manually identify the team and "
+                                    f"use `/set-ticket-match` to set the correct match number."
+                                ),
+                                color=discord.Color.orange(),
+                            )
+                            if lookup.get("best_team"):
+                                embed.add_field(
+                                    name="Closest Match",
+                                    value=f"`{lookup['best_team']}` ({lookup.get('best_ratio', 0):.0%} similarity)",
+                                    inline=False,
+                                )
+                            embed.set_footer(text=f"Matcherino ID: {m_id}")
+                            await new_channel.send(embed=embed)
 
 
 class TourneyOpenTicketView(discord.ui.View):


### PR DESCRIPTION
### Changes
- Adds find_match_by_team_name() in matcherino.py — fuzzy-matches a team name against all bracket entrants and resolves their current match number, with a per-tourney   
  in-memory cache so the team list is only built once per session                                                                                                          
- Fallback triggers in three cases: non-numeric match input, match number not found in bracket, or team name doesn't match either team in the given match — auto-corrects
   the ticket topic and shows the resolved match embed                                                                                                                     
- Cache is cleared on !endtourney; no additional API calls since all lookups hit the existing 60s requests_cache    

### Screenshots
Originally match number is wrong so it searches for the correct team and corrects the match number and team name:
<img width="648" height="904" alt="image" src="https://github.com/user-attachments/assets/00a87f66-fef2-439d-aa85-151fd1e1198e" />

Closes #171