### PR TITLE
173-Enhancement update readme and all help commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Remaining7-Discord-Bot/
 │   ├── quests.py                    # Daily & weekly quest system
 │   ├── security.py                  # Hacked protocol (timeout, purge, flag)
 │   ├── event.py                     # Event channel cleanup & reward payouts
-│   ├── general.py                   # /help, /mod-help, /admin-help
+│   ├── general.py                   # /help, /mod-help, /admin-help, /convert-time
 │   ├── translation.py               # !t prefix & /translate slash command (55 languages)
 │   ├── support_tickets.py           # General support tickets (issues, support, apps, partnership)
 │   ├── ticket_command_router.py     # Shared routing for tourney & support ticket commands
@@ -64,8 +64,8 @@ Remaining7-Discord-Bot/
 ## Core Features
 
 ### R7 Token Economy
-- **Passive Income:** Users earn 2–5 R7 Tokens per message (1-minute cooldown).
-- **Daily Rewards:** `/daily` with streak tracking and level-based bonus.
+- **Passive Income:** Users earn 2–5 R7 Tokens per message (20-second cooldown). Server Boosters get a 2% average bonus.
+- **Daily Rewards:** `/daily` grants 80–160 tokens (scaled by level). Requires 5 messages sent since last claim and a 24-hour cooldown.
 - **Supply Drop:** `/drop <amount>` (Admin) to force a token drop in general chat.
 - **Balance & Ranking:** `/balance [user]`, `/leaderboard [page]`.
 - **Give & Set:** `/give <user> <token/xp/level> <amount>`, `/set-balance <user> <amount>` (Admin).
@@ -108,7 +108,7 @@ Remaining7-Discord-Bot/
 
 ### Tournament System
 - **Phase Management:**
-  - `!starttourney [region]` — start live tournament, reset counters, init queue dashboard.
+  - `!starttourney [region]` — start live tournament, reset counters, init queue dashboard. Use `!starttourney SA` for South America mode.
   - `!endtourney` — end tournament, clean up dashboards and tickets.
 - **Ticket Panels:** `/tourney-panel` (live) and `/pre-tourney-panel` (pre-tourney) post interactive open buttons.
 - **Ticket Operations:**
@@ -129,8 +129,9 @@ Remaining7-Discord-Bot/
 - **Blacklist:** `/blacklist add/remove/list` — manage banned users (Discord ID, Matcherino profile, reason, alts).
 - **Rate Limits:** Max 3 open tickets per user, 180s cooldown. Auto-reopen after 6-hour lock.
 - **Auto-translation:** Ticket messages auto-translated via `deep-translator` + `langdetect`.
-- **Test Mode:** `/tourney-test-mode` — toggle dynamic rate limits for testing.
+- **Test Mode:** `/tourney-test-mode` — toggle 100-ticket limit and 0.1s cooldown for testing.
 - **Staff Guide:** `/tourney-admin-help`.
+- **SA Mode:** South America region variant with separate ticket categories and region-specific workflow.
 
 ### Tournament Admin Compensation
 - `/payout-add <users...> <amount>` — record staff payouts (Split or Flat mode).
@@ -167,10 +168,16 @@ Remaining7-Discord-Bot/
 - `/translate <language> <phrase>` — translate English text into any of 55 supported languages.
 - Auto-detects source language. Google Translate backend.
 
+### Utility
+- `/convert-time <date> <time> <timezone>` — convert a date and time to all Discord timestamp formats. Supports 20+ timezone aliases (EST, PT, GMT, etc.) and IANA names.
+
 ### Help Commands
 - `/help` — user command directory.
+- `/economy-help` — full guide to earning and spending R7 Tokens.
 - `/mod-help` — moderator guide (economy oversight, security protocol).
 - `/admin-help` — admin manual (economy, events, security, tournaments, financials).
+- `/tourney-admin-help` — tournament staff cheat sheet.
+- `/event-staff-help` — event channel management guide.
 
 ---
 
@@ -237,12 +244,13 @@ Uses MongoDB database `r7_bot_db` with the following collections:
 
 | Task | Schedule | Description |
 |---|---|---|
-| Message listener | On every message | Passive token + XP generation (1-min cooldown) |
+| Message listener | On every message | Passive token + XP generation (20s cooldown) |
 | Quest tracker | On every message | Track quest progress, auto-complete and reward |
 | Event cleanup | Daily at 12:00 AM ET | Scan event channels for stale messages |
 | Queue dashboard | Every 15 seconds | Update tourney queue embed during live tournaments |
-| Progress dashboard | During tournaments | Semi-final/final bracket announcements |
-| Match refresher | During tournaments | Monitor active Matcherino tickets |
+| Supply drop | Every 6 hours | Random token drop in general chat |
+| Progress dashboard | Every 5 minutes (live) | Semi-final/final bracket announcements |
+| Match refresher | Every 1 minute (live) | Refresh Matcherino scores in active tickets |
 | Budget reset | On interaction | Auto-reset monthly redemption cap on month change |
 
 ---
@@ -270,4 +278,3 @@ Uses MongoDB database `r7_bot_db` with the following collections:
 ## Future Roadmap
 - [ ] Brawl Stars: View for a specific brawler's details
 - [ ] Giveaway system with extra entries via R7 Tokens
-- [ ] Tracker for rewards given away

--- a/features/economy.py
+++ b/features/economy.py
@@ -1350,14 +1350,15 @@ class Economy(commands.Cog):
             "**Standard Commands:**\n"
             "`/balance` - View your token total\n"
             "`/daily` - Claim daily tokens & check progress\n"
+            "`/quests` - View active daily and weekly quests\n"
             "`/leaderboard` - See top token holders\n"
             "`/level` - Check your rank & XP progress\n"
-            "`/levels_leaderboard` - See top server levels\n"
+            "`/levels-leaderboard` - See top server levels\n"
             "`/shop` - Browse the token store\n"
             "`/buy` - Purchase an item from the shop\n"
             "`/redeem` - Claim your purchased rewards\n\n"
             "**Utility:**\n"
-            "`/checkbudget` - See remaining monthly reward budget"
+            "`/check-budget` - See remaining monthly reward budget"
         )
         cmd_embed.description = cmd_text
 

--- a/features/event.py
+++ b/features/event.py
@@ -433,6 +433,13 @@ class Events(commands.Cog):
         )
         embed.add_field(name="🧹 Manual Purge Commands", value=mgmt_text, inline=False)
 
+        # --- Reward Distribution ---
+        reward_text = (
+            "`/event-rewards <message_id>` - Process token distribution from an announcement message.\n"
+            "*(Message must use `@User 500` format. Admin only.)*"
+        )
+        embed.add_field(name="🏆 Reward Distribution", value=reward_text, inline=False)
+
         # --- Automated Cleanup ---
         cleanup_text = (
             "Every day at **12:00 AM ET**, the bot checks for messages older than **7 days**.\n"

--- a/features/general.py
+++ b/features/general.py
@@ -14,12 +14,11 @@ class General(commands.Cog):
     @app_commands.command(name="help", description="View all available bot commands.")
     async def help_command(self, interaction: discord.Interaction):
         embed = discord.Embed(
-            # 2. Add it right to the title!
             title=f"🤖 **R7 Bot Command Directory | {BOT_VERSION}**",
             description=(
                 "Here is a list of all the commands you can use in the server!\n\n"
                 "💡 **Want to know how to get tokens?**\n"
-                "Use `/economy_help` for a full guide on earning and spending."
+                "Use `/economy-help` for a full guide on earning and spending."
             ),
             color=discord.Color.blurple(),
         )
@@ -30,20 +29,20 @@ class General(commands.Cog):
             "`/quests` - View active daily and weekly quests\n"
             "`/leaderboard` - See top token holders\n"
             "`/level` - Check your rank & XP progress\n"
-            "`/levels_leaderboard` - See top server levels\n"
+            "`/levels-leaderboard` - See top server levels\n"
             "`/shop` - Browse the token store\n"
             "`/buy` - Purchase an item from the shop\n"
             "`/redeem` - Claim your purchased rewards\n"
-            "`/checkbudget` - See remaining monthly reward budget"
+            "`/check-budget` - See remaining monthly reward budget"
         )
         embed.add_field(name="💰 Economy", value=economy_text, inline=False)
 
         brawler_text = (
             "`/profile` - View your profile, collection progress, and currencies\n"
             "`/brawlers` - View your owned brawlers and their levels\n"
-            "`/buy_brawler` - Purchase new brawlers using Credits\n"
+            "`/buy-brawler` - Purchase new brawlers using Credits\n"
             "`/upgrade` - Level up your brawlers\n"
-            "`/buy_ability` - Buy Gadgets, Star Powers, and Hypercharges\n"
+            "`/buy-ability` - Buy Gadgets, Star Powers, and Hypercharges\n"
             "`/megabox` - Open a Mega Box\n"
             "`/starrdrop` - Open a random Starr Drop"
         )
@@ -62,6 +61,11 @@ class General(commands.Cog):
             "`/translate` - Translate your English text into 55 other languages"
         )
         embed.add_field(name="🌐 Translation", value=translation_text, inline=False)
+
+        utility_text = (
+            "`/convert-time` - Convert a date and time to Discord timestamp formats"
+        )
+        embed.add_field(name="🔧 Utility", value=utility_text, inline=False)
 
         embed.set_footer(text="Staff & Admin commands are hidden from this list.")
         embed.set_thumbnail(url=self.bot.user.display_avatar.url)

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -2242,15 +2242,17 @@ def setup_tourney_commands(bot: commands.Bot):
 
         # --- 1. Session & Channel Management ---
         session_text = (
-            "`!starttourney` - Wipes old tickets, locks the general server support channel, and posts the live support panel.\n"
+            "`!starttourney [region]` - Wipes old tickets, locks general support, and posts the live panel. Use `!starttourney SA` for South America mode.\n"
             "`!endtourney` - Closes all active tickets, generates staff stats, posts the Pre-Tourney panel, and unlocks general support.\n"
-            "`!lock` / `!unlock` - Manually close or open the general server support channel."
+            "`!lock` / `!unlock` - Manually close or open the general server support channel.\n"
+            "`/tourney-test-mode` - Toggle 100-ticket limit and 0.1s cooldown for testing."
         )
         embed.add_field(name="⚙️ Session Management", value=session_text, inline=False)
 
         # --- 2. Ticket Commands ---
         ticket_text = (
             "`!close` (or `!c`) - Closes the current ticket and adds to your completed stats.\n"
+            "`!delete` (or `!del`) - Deletes a ticket with transcript.\n"
             "`!reopen` - Moves a closed ticket back to the active category.\n"
             "`/add` / `/remove` - Add or remove a specific user to/from the current ticket."
         )
@@ -2261,7 +2263,8 @@ def setup_tourney_commands(bot: commands.Bot):
             "`/set-matcherino` - Set the active Matcherino bracket ID for the session.\n"
             "`/match-info` - Show live rosters, scores, and match status for a match number.\n"
             "`/match-history` - Show a team's previous rounds for a given match.\n"
-            "`/set-ticket-match` - Correct this ticket's match number or team name."
+            "`/set-ticket-match` - Correct this ticket's match number or team name.\n"
+            "`/tourney-progress` - Real-time bracket health check with stage announcements."
         )
         embed.add_field(
             name="📊 Live Bracket / Matcherino", value=matcherino_text, inline=False


### PR DESCRIPTION
### Changes
  - Fix incorrect command names across all help embeds (/economy_help → /economy-help, /checkbudget → /check-budget, /buy_brawler → /buy-brawler, etc.) and add missing    
  commands (/convert-time, /quests, /event-rewards, !delete, /tourney-progress, /tourney-test-mode)                                                                        
  - Update README to reflect current behavior: 20s passive token cooldown, daily 5-message requirement, supply drop/progress/match-refresher task intervals, SA mode, and  
  all help command listings                                                                                                                                                
  - Expand /tourney-admin-help with SA mode, test mode toggle, and full ticket/bracket toolset                                                                             

Closes #173