### PR TITLE
196-Bug clear stale matcherino id on tournament start

### DIFF
--- a/database/mongo.py
+++ b/database/mongo.py
@@ -803,7 +803,7 @@ async def reset_tourney_session_start_time(session_id):
     try:
         result = await db.tourney_sessions.update_one(
             {"_id": session_id, "status": "active"},
-            {"$set": {"start_time": datetime.utcnow()}},
+            {"$set": {"start_time": datetime.utcnow(), "matcherino_id": None}},
         )
         return result.modified_count > 0
     except Exception as e:

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -1403,7 +1403,7 @@ def setup_tourney_commands(bot: commands.Bot):
                             print(f"Failed to delete pre-tourney ticket {ch.name}: {e}")
 
         await ctx.send(
-            f"✅ Tourney Started! Channels updated and {deleted_count} pre-tourney tickets deleted."
+            f"✅ Tourney Started! Channels updated and {deleted_count} pre-tourney tickets deleted.\n⚠️ Don't forget to set the new Matcherino ID with `/set-matcherino`."
         )
 
         # Grant Tourney Admin the Timeout Members permission for the duration of the tourney.
@@ -1419,6 +1419,23 @@ def setup_tourney_commands(bot: commands.Bot):
         # START THE DASHBOARD
         dashboard_cog = bot.get_cog("QueueDashboard")
         if dashboard_cog:
+            dashboard_cog._announcement_matcherino_id = None
+            dashboard_cog._winner_announcement_state = {
+                "winner": None,
+                "message_id": None,
+            }
+            dashboard_cog._stage_announcement_state = {
+                "semi_finals": {
+                    "signature": None,
+                    "message_id": None,
+                    "hype_message_id": None,
+                },
+                "finals": {
+                    "signature": None,
+                    "message_id": None,
+                    "hype_message_id": None,
+                },
+            }
             await dashboard_cog.start_dashboard()
 
     @bot.command(name="endtourney")


### PR DESCRIPTION
Changes 
  - Clear stored Matcherino ID from the database when `!starttourney` reuses an existing session                                                                             
  - Reset in-memory winner and match announcement states on the dashboard cog at tournament start                                                                        
  - Add `/set-matcherino` reminder to the `!starttourney` confirmation message         

Closes #196