### PR TITLE
205-Feature tourney snapshot data collection for ML training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ venv/
 .venv/
 
 api_debug.json
+snapshot_debug.json
 
 .claude/
 CLAUDE.md

--- a/database/mongo.py
+++ b/database/mongo.py
@@ -884,13 +884,32 @@ async def get_top_staff_stats(session_id, limit: int = 12):
         return []
 
 
-async def update_matcherino_id(session_id: str, matcherino_id: str):
+async def update_matcherino_id(
+    session_id: str, matcherino_id: str, collect_data: bool = None
+):
     """Saves the Matcherino ID to the active tournament session."""
     if tourney_sessions is None:
         return
+    update_fields = {"matcherino_id": matcherino_id}
+    if collect_data is not None:
+        update_fields["collect_data"] = collect_data
+    await tourney_sessions.update_one({"_id": session_id}, {"$set": update_fields})
+
+
+async def set_tourney_collect_data(session_id, enabled: bool):
+    """Sets the collect_data flag on a tournament session."""
+    if tourney_sessions is None:
+        return
     await tourney_sessions.update_one(
-        {"_id": session_id}, {"$set": {"matcherino_id": matcherino_id}}
+        {"_id": session_id}, {"$set": {"collect_data": enabled}}
     )
+
+
+async def insert_tourney_snapshot(snapshot: dict):
+    """Inserts a single snapshot document into tourney_snapshots."""
+    if db is None:
+        return
+    await db["tourney_snapshots"].insert_one(snapshot)
 
 
 async def get_matcherino_id_from_active():

--- a/database/mongo.py
+++ b/database/mongo.py
@@ -912,6 +912,16 @@ async def insert_tourney_snapshot(snapshot: dict):
     await db["tourney_snapshots"].insert_one(snapshot)
 
 
+async def get_last_tourney_snapshot(tourney_id: str):
+    """Returns the most recent snapshot for a tourney, or None."""
+    if db is None:
+        return None
+    return await db["tourney_snapshots"].find_one(
+        {"tourney_id": tourney_id},
+        sort=[("snapshot_at", -1)],
+    )
+
+
 async def get_matcherino_id_from_active():
     """Retrieves the Matcherino ID from the currently active session."""
     session = await get_active_tourney_session()

--- a/features/tourney/matcherino.py
+++ b/features/tourney/matcherino.py
@@ -708,22 +708,26 @@ def fetch_bracket_progress(url: str) -> dict:
                 }
             )
 
-    # --- Snapshot timestamp helpers (POC) ---
-    done_timestamps = []
-    for m in closed_matches:
-        ts = m.get("statusAt")
-        if ts:
-            done_timestamps.append(ts)
-
-    active_timestamps = []
-    for m in active_matches:
+    # --- Per-round timestamp data (for snapshot round_duration) ---
+    round_timestamps = {}
+    for m in real_matches:
+        r = m["resolved_round"]
+        if r not in round_timestamps:
+            round_timestamps[r] = {
+                "start_candidates": [],
+                "end_candidates": [],
+                "match_count": 0,
+            }
+        round_timestamps[r]["match_count"] += 1
+        # min(statusAt) across all matches in the round = round start proxy
         ts = m.get("statusAt") or m.get("createdAt")
         if ts:
-            active_timestamps.append(ts)
-
-    matches_in_dominant = sum(
-        1 for m in real_matches if m["resolved_round"] == dominant_round
-    )
+            round_timestamps[r]["start_candidates"].append(ts)
+        # max(endAt) across done matches only = round end proxy
+        if str(m.get("status", "")).lower() in finished_statuses:
+            end_ts = m.get("endAt") or m.get("statusAt")
+            if end_ts:
+                round_timestamps[r]["end_candidates"].append(end_ts)
 
     return {
         "status": "success",
@@ -745,9 +749,5 @@ def fetch_bracket_progress(url: str) -> dict:
             all_match_details,
             key=lambda x: (x["round"], x["id"] if isinstance(x["id"], int) else 9999),
         ),
-        "latest_done_status_at": max(done_timestamps) if done_timestamps else None,
-        "earliest_active_status_at": min(active_timestamps)
-        if active_timestamps
-        else None,
-        "matches_in_dominant_round": matches_in_dominant,
+        "round_timestamps": round_timestamps,
     }

--- a/features/tourney/matcherino.py
+++ b/features/tourney/matcherino.py
@@ -708,6 +708,23 @@ def fetch_bracket_progress(url: str) -> dict:
                 }
             )
 
+    # --- Snapshot timestamp helpers (POC) ---
+    done_timestamps = []
+    for m in closed_matches:
+        ts = m.get("statusAt")
+        if ts:
+            done_timestamps.append(ts)
+
+    active_timestamps = []
+    for m in active_matches:
+        ts = m.get("statusAt") or m.get("createdAt")
+        if ts:
+            active_timestamps.append(ts)
+
+    matches_in_dominant = sum(
+        1 for m in real_matches if m["resolved_round"] == dominant_round
+    )
+
     return {
         "status": "success",
         "total": total_matches,
@@ -728,4 +745,9 @@ def fetch_bracket_progress(url: str) -> dict:
             all_match_details,
             key=lambda x: (x["round"], x["id"] if isinstance(x["id"], int) else 9999),
         ),
+        "latest_done_status_at": max(done_timestamps) if done_timestamps else None,
+        "earliest_active_status_at": min(active_timestamps)
+        if active_timestamps
+        else None,
+        "matches_in_dominant_round": matches_in_dominant,
     }

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -33,6 +33,7 @@ from database.mongo import (
     increment_staff_closure,
     get_top_staff_stats,
     get_matcherino_id_from_active,
+    insert_tourney_snapshot,
 )
 
 # Import Config and Utils
@@ -100,6 +101,50 @@ class PayoutResetConfirmView(discord.ui.View):
         self.value = False
         await interaction.response.defer()
         self.stop()
+
+
+class MLDataCollectionPromptView(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=60)
+        self.value = None
+
+    @discord.ui.button(
+        label="Enable ML Data Collection", style=discord.ButtonStyle.green
+    )
+    async def enable(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.value = True
+        await interaction.response.defer()
+        self.stop()
+
+    @discord.ui.button(label="Skip", style=discord.ButtonStyle.grey)
+    async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.value = False
+        await interaction.response.defer()
+        self.stop()
+
+
+async def _write_snapshot(data: dict, session: dict):
+    """Write a tournament state snapshot to MongoDB."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    snapshot = {
+        "timestamp": now.isoformat(),
+        "matcherino_id": session.get("matcherino_id"),
+        "dominant_round": data.get("dominant_round"),
+        "max_round": data.get("max_round"),
+        "round_position_from_end": data.get("max_round", 0)
+        - data.get("dominant_round", 0),
+        "matches_in_dominant_round": data.get("matches_in_dominant_round"),
+        "bottleneck_count": len(data.get("bottlenecks", [])),
+        "completion_pct": data.get("completion_pct"),
+        "total_matches": data.get("total"),
+        "closed_matches": data.get("closed"),
+        "active_count": data.get("active_count"),
+        "time_of_day": now.hour + now.minute / 60,
+        "day_of_week": now.weekday(),
+        "latest_done_status_at": data.get("latest_done_status_at"),
+        "earliest_active_status_at": data.get("earliest_active_status_at"),
+    }
+    await insert_tourney_snapshot(snapshot)
 
 
 class QueueDashboard(commands.Cog):
@@ -467,6 +512,13 @@ class QueueDashboard(commands.Cog):
             data = fetch_bracket_progress(bracket_url)
             if data.get("status") != "success":
                 return
+
+            # --- POC: Snapshot data collection ---
+            if session.get("collect_data"):
+                try:
+                    await _write_snapshot(data, session)
+                except Exception as e:
+                    print(f"⚠️ Snapshot collection error: {e}")
 
             try:
                 await self.announce_high_stakes_matches(m_id, data)
@@ -956,9 +1008,11 @@ class QueueDashboard(commands.Cog):
             except Exception as e:
                 print(f"Refresher error in {channel.name}: {e}")
 
-    @tasks.loop(minutes=5)
+    @tasks.loop(
+        minutes=1
+    )  # TODO: revert to minutes=5 before merging to main (snapshot POC testing)
     async def progress_dashboard_task(self):
-        """Refreshes the tournament progress dashboard every 5 minutes."""
+        """Refreshes the tournament progress dashboard every 1 minute (POC testing)."""
         await self.bot.wait_until_ready()
         await self.update_progress_dashboard()
 
@@ -2336,8 +2390,13 @@ def setup_tourney_commands(bot: commands.Bot):
     @app_commands.command(
         name="set-matcherino", description="STAFF ONLY: Set the active Matcherino ID."
     )
-    @app_commands.describe(m_id="The numeric Matcherino ID (e.g., 180454)")
-    async def set_matcherino(interaction: discord.Interaction, m_id: str):
+    @app_commands.describe(
+        m_id="The numeric Matcherino ID (e.g., 180454)",
+        collect_data="Enable ML training data collection for this tournament",
+    )
+    async def set_matcherino(
+        interaction: discord.Interaction, m_id: str, collect_data: bool = False
+    ):
         if not is_staff(interaction.user):
             await interaction.response.send_message(
                 "❌ Permission denied.", ephemeral=True
@@ -2359,10 +2418,15 @@ def setup_tourney_commands(bot: commands.Bot):
             )
             return
 
-        await update_matcherino_id(active_session["_id"], clean_id)
-        await interaction.response.send_message(
-            f"✅ Active Matcherino ID set to: `{clean_id}`", ephemeral=True
+        await update_matcherino_id(
+            active_session["_id"],
+            clean_id,
+            collect_data=collect_data,
         )
+        msg = f"✅ Active Matcherino ID set to: `{clean_id}`"
+        if collect_data:
+            msg += " | 🧪 ML data collection enabled."
+        await interaction.response.send_message(msg, ephemeral=True)
 
     @app_commands.command(
         name="tourney-test-mode",

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -1008,9 +1008,7 @@ class QueueDashboard(commands.Cog):
             except Exception as e:
                 print(f"Refresher error in {channel.name}: {e}")
 
-    @tasks.loop(
-        minutes=1
-    )  # TODO: revert to minutes=5 before merging to main (snapshot POC testing)
+    @tasks.loop(minutes=5)
     async def progress_dashboard_task(self):
         """Refreshes the tournament progress dashboard every 1 minute (POC testing)."""
         await self.bot.wait_until_ready()

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -33,7 +33,9 @@ from database.mongo import (
     increment_staff_closure,
     get_top_staff_stats,
     get_matcherino_id_from_active,
+    set_tourney_collect_data,
     insert_tourney_snapshot,
+    get_last_tourney_snapshot,
 )
 
 # Import Config and Utils
@@ -103,46 +105,62 @@ class PayoutResetConfirmView(discord.ui.View):
         self.stop()
 
 
-class MLDataCollectionPromptView(discord.ui.View):
-    def __init__(self):
-        super().__init__(timeout=60)
-        self.value = None
-
-    @discord.ui.button(
-        label="Enable ML Data Collection", style=discord.ButtonStyle.green
-    )
-    async def enable(self, interaction: discord.Interaction, button: discord.ui.Button):
-        self.value = True
-        await interaction.response.defer()
-        self.stop()
-
-    @discord.ui.button(label="Skip", style=discord.ButtonStyle.grey)
-    async def skip(self, interaction: discord.Interaction, button: discord.ui.Button):
-        self.value = False
-        await interaction.response.defer()
-        self.stop()
-
-
 async def _write_snapshot(data: dict, session: dict):
-    """Write a tournament state snapshot to MongoDB."""
+    """Write a snapshot on every poll; include round_duration only on transition."""
+    tourney_id = session.get("matcherino_id")
+    if not tourney_id:
+        return
+
+    current_dominant = data.get("dominant_round")
+    if current_dominant is None:
+        return
+
+    # Check for round transition
+    last_snapshot = await get_last_tourney_snapshot(tourney_id)
+    last_dominant = last_snapshot.get("dominant_round") if last_snapshot else None
+
+    is_transition = last_dominant is None or last_dominant != current_dominant
+
+    # On transition, compute round_duration for the completed round
+    round_duration = None
+    match_count = 0
+    if is_transition:
+        completed_round = (
+            last_dominant if last_dominant is not None else current_dominant
+        )
+        round_ts = data.get("round_timestamps", {}).get(completed_round, {})
+        match_count = round_ts.get("match_count", 0)
+
+        start_candidates = round_ts.get("start_candidates", [])
+        end_candidates = round_ts.get("end_candidates", [])
+        if start_candidates and end_candidates:
+            try:
+                start_dt = datetime.datetime.fromisoformat(
+                    min(start_candidates).replace("Z", "+00:00")
+                )
+                end_dt = datetime.datetime.fromisoformat(
+                    max(end_candidates).replace("Z", "+00:00")
+                )
+                round_duration = (end_dt - start_dt).total_seconds()
+            except (ValueError, TypeError):
+                pass
+
     now = datetime.datetime.now(datetime.timezone.utc)
+    max_round = data.get("max_round", 0)
+
     snapshot = {
-        "timestamp": now.isoformat(),
-        "matcherino_id": session.get("matcherino_id"),
-        "dominant_round": data.get("dominant_round"),
-        "max_round": data.get("max_round"),
-        "round_position_from_end": data.get("max_round", 0)
-        - data.get("dominant_round", 0),
-        "matches_in_dominant_round": data.get("matches_in_dominant_round"),
+        "tourney_id": tourney_id,
+        "snapshot_at": now.isoformat(),
+        "dominant_round": current_dominant,
+        "round_position_from_end": max_round - current_dominant,
+        "match_count_in_round": match_count if is_transition else None,
+        "round_duration": round_duration,
+        "duration_per_match": (round_duration / match_count)
+        if round_duration and match_count
+        else None,
         "bottleneck_count": len(data.get("bottlenecks", [])),
-        "completion_pct": data.get("completion_pct"),
-        "total_matches": data.get("total"),
-        "closed_matches": data.get("closed"),
-        "active_count": data.get("active_count"),
-        "time_of_day": now.hour + now.minute / 60,
+        "time_of_day": now.hour,
         "day_of_week": now.weekday(),
-        "latest_done_status_at": data.get("latest_done_status_at"),
-        "earliest_active_status_at": data.get("earliest_active_status_at"),
     }
     await insert_tourney_snapshot(snapshot)
 
@@ -1455,7 +1473,7 @@ def setup_tourney_commands(bot: commands.Bot):
                             print(f"Failed to delete pre-tourney ticket {ch.name}: {e}")
 
         await ctx.send(
-            f"✅ Tourney Started! Channels updated and {deleted_count} pre-tourney tickets deleted.\n⚠️ Don't forget to set the new Matcherino ID with `/set-matcherino`."
+            f"✅ Tourney Started! Channels updated and {deleted_count} pre-tourney tickets deleted.\n⚠️ Don't forget to set the new Matcherino ID with `/set-matcherino` and enable ML data collection if needed."
         )
 
         # Grant Tourney Admin the Timeout Members permission for the duration of the tourney.
@@ -1667,6 +1685,7 @@ def setup_tourney_commands(bot: commands.Bot):
 
             # 4. Close Session in DB
             await end_tourney_session(session["_id"])
+            await set_tourney_collect_data(session["_id"], False)
             clear_bracket_teams_cache()
         # ------------------------------
 


### PR DESCRIPTION
### Changes
* Added `collect_data` boolean param to `/set-matcherino` (defaults False) to opt into ML training data collection per tourney
* Added `set_tourney_collect_data` and `get_last_tourney_snapshot` helpers to `mongo.py`; added optional `collect_data` param to `update_matcherino_id`
* Added `insert_tourney_snapshot` helper to `mongo.py` writing to new `tourney_snapshots` collection
* Added per-round `round_timestamps` dict to `fetch_bracket_progress` return value in `matcherino.py`, exposing `start_candidates`, `end_candidates` (endAt from done matches, statusAt fallback), and `match_count` per round
* Added `_write_snapshot` to `tourney_commands.py` — writes a snapshot to `tourney_snapshots` on every progress dashboard poll when `collect_data` is True; calculates `round_duration` and `duration_per_match` only on round transitions
* Added `collect_data` guard to `update_progress_dashboard` poll hook
* Updated `!starttourney` reminder to mention ML data collection
* Added `collect_data` reset to False in `!endtourney`
* Added `snapshot_debug.json` to `.gitignore`


Part of #203
Closes #205