### PR TITLE
197-Enhancement make `/set-matcherino` id command response public

### DIFF
--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -2443,7 +2443,7 @@ def setup_tourney_commands(bot: commands.Bot):
         msg = f"✅ Active Matcherino ID set to: `{clean_id}`"
         if collect_data:
             msg += " | 🧪 ML data collection enabled."
-        await interaction.response.send_message(msg, ephemeral=True)
+        await interaction.response.send_message(msg)
 
     @app_commands.command(
         name="tourney-test-mode",


### PR DESCRIPTION
### Changes 
- Remove ephemeral flag from `/set-matcherino` confirmation so all staff can see when the tourney ID is updated


Closes #197