### PR TITLE
213-Feature add github tickets cog with bot mention listener

### DIFF
--- a/features/github_tickets.py
+++ b/features/github_tickets.py
@@ -1,0 +1,33 @@
+import re
+
+import discord
+from discord.ext import commands
+
+
+class GitHubTickets(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot:
+            return
+
+        if not re.search(rf"<@!?{self.bot.user.id}>", message.content):
+            return
+
+        raw_text = re.sub(rf"<@!?{self.bot.user.id}>", "", message.content).strip()
+
+        if not raw_text:
+            await message.reply(
+                "@ me with a description of your bug, enhancement, or feature"
+                " and I'll create a GitHub issue."
+            )
+            return
+
+        # TODO: Pass raw_text to Gemini integration
+        await message.reply(f"Received: {raw_text}")
+
+
+async def setup(bot):
+    await bot.add_cog(GitHubTickets(bot))

--- a/main.py
+++ b/main.py
@@ -67,6 +67,9 @@ async def on_ready():
         await bot.load_extension("features.support_tickets")
         print("✅ Loaded Feature: Support Tickets")
 
+        await bot.load_extension("features.github_tickets")
+        print("✅ Loaded Feature: GitHub Tickets")
+
     except Exception as e:
         print(f"❌ Error loading features: {e}")
 


### PR DESCRIPTION
### Changes 
- Add GitHub tickets cog that listens for bot @mentions and extracts raw text for downstream Gemini integration.                                                           
- Empty mentions reply with a usage hint; reply-mentions without an explicit @ are ignored.  

### Screenshots
Bot receiving the message on @mention:
<img width="459" height="138" alt="image" src="https://github.com/user-attachments/assets/dc4b12d9-d7f6-4708-a99e-d72be8509850" />

Bot not responding when it's only a reply ping:
<img width="403" height="105" alt="image" src="https://github.com/user-attachments/assets/d6ca04ed-2e48-40b5-aeef-f9e5a1a50feb" />

Part of #210 
Closes #213 