### PR TITLE
215-Feature add Gemini integration for GitHub issue classification

### DIFF
--- a/features/github_tickets.py
+++ b/features/github_tickets.py
@@ -1,7 +1,181 @@
+import json
+import os
 import re
 
+import aiohttp
 import discord
 from discord.ext import commands
+
+GEMINI_TOKEN = os.getenv("GEMINI_TOKEN")
+GEMINI_API_URL = (
+    "https://generativelanguage.googleapis.com/v1beta/models/"
+    "gemini-2.5-flash:generateContent"
+)
+
+BUG_TEMPLATE = """\
+Bug: <Small desc of the bug>
+
+### Overview
+Provide a clear and concise description of the bug. Include any relevant background information.
+
+### Acceptance Criteria
+How do we know it's done?
+- [ ] [criteria #1]
+- [ ] [criteria #2]
+
+### Steps to Reproduce Bug
+- [ ] [Step #1]
+- [ ] [Step #2]
+- [ ] [Step #3]
+
+### Impact
+Describe how this affects users, performance, or other parts of the system.
+
+### Screenshots/Logs [if applicable]
+Attach screenshots, error logs, or any relevant artifacts.
+
+### Branch
+```
+-Bug
+```"""
+
+ENHANCEMENT_TEMPLATE = """\
+Enhancement: <small desc of the enhancement>
+
+### Overview
+1-2 sentences describing the improvement and which existing feature it modifies.
+
+### Current Behavior
+Describe how the feature currently functions or the limitation that exists.
+
+### Proposed Behavior
+Describe the desired improvement, optimization, or UI change.
+
+### Technical Requirements
+- [ ] [Specific change or refactor #1]
+- [ ] [Specific change or refactor #2]
+
+### Acceptance Criteria
+- [ ] [criteria #1]
+- [ ] [criteria #2]
+
+### Benefit/Impact
+Why is this improvement necessary? (e.g., Better UX, improved performance, cleaner code).
+
+### Branch
+```
+-Enhancement
+```"""
+
+FEATURE_TEMPLATE = """\
+Feature: <small desc of the feature>
+
+### Overview
+
+1-2 sentences describing what this sub-issue accomplishes and how it contributes to the user story
+
+### Technical Requirements
+
+- [ ] [Specific implementation detail 1]
+
+- [ ] [Specific implementation detail 2]
+
+### Acceptance Criteria
+
+- [ ] [criteria #1]
+
+- [ ] [criteria #2]
+
+### Notes
+
+Any additional context, links, or questions.
+
+### Branch
+```
+-Feature
+```"""
+
+GEMINI_PROMPT = """\
+You are a GitHub issue writer for a Discord bot project. Given a user's description, \
+determine whether it is a bug report, an enhancement to an existing feature, or a new \
+feature request. Then generate a GitHub issue using the matching template below.
+
+TEMPLATES:
+--- BUG ---
+{bug}
+
+--- ENHANCEMENT ---
+{enhancement}
+
+--- FEATURE ---
+{feature}
+
+RULES:
+- Return ONLY a raw JSON object with exactly three keys: "type", "title", "body"
+- "type" must be one of: "bug", "enhancement", "feature"
+- "title" must be a concise issue title (under 80 characters)
+- "body" must be the filled-in template as a single string (use \\n for newlines)
+- Fill in template sections with reasonable detail based on the description
+- Use placeholder checkboxes for acceptance criteria and steps
+- Do NOT hallucinate specifics beyond what the description provides
+- Do NOT wrap the JSON in markdown code fences or add any preamble/explanation
+
+USER DESCRIPTION:
+{description}"""
+
+
+async def call_gemini(raw_text: str) -> dict:
+    """Call Gemini 2.0 Flash API to classify and structure a GitHub issue."""
+    if not GEMINI_TOKEN:
+        raise RuntimeError("GEMINI_TOKEN environment variable is not set.")
+
+    prompt = GEMINI_PROMPT.format(
+        bug=BUG_TEMPLATE,
+        enhancement=ENHANCEMENT_TEMPLATE,
+        feature=FEATURE_TEMPLATE,
+        description=raw_text,
+    )
+
+    payload = {"contents": [{"parts": [{"text": prompt}]}]}
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            GEMINI_API_URL,
+            params={"key": GEMINI_TOKEN},
+            json=payload,
+        ) as resp:
+            if resp.status != 200:
+                error_text = await resp.text()
+                raise RuntimeError(
+                    f"Gemini API returned status {resp.status}: {error_text}"
+                )
+
+            data = await resp.json()
+
+    try:
+        text = data["candidates"][0]["content"]["parts"][0]["text"]
+    except (KeyError, IndexError) as e:
+        raise RuntimeError(f"Unexpected Gemini response structure: {e}") from e
+
+    # Strip markdown fences if Gemini returns them despite instructions
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+
+    try:
+        result = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Gemini returned invalid JSON: {e}\nRaw: {text}") from e
+
+    for key in ("type", "title", "body"):
+        if key not in result:
+            raise RuntimeError(f"Gemini response missing required key: '{key}'")
+
+    if result["type"] not in ("bug", "enhancement", "feature"):
+        raise RuntimeError(f"Gemini returned invalid type: '{result['type']}'")
+
+    return result
 
 
 class GitHubTickets(commands.Cog):


### PR DESCRIPTION
### Changes
  - Adds call_gemini() async function that POSTs to Gemini 2.5 Flash API to classify user descriptions as bug/enhancement/feature                                          
  - Stores all three ticket templates as constants and builds a structured prompt that returns a JSON dict with type, title, and body                                      
  - Validates API response with defensive parsing for markdown fences, missing keys, and invalid types
  
  
 ### Logs
Calling the Gemini api accurate classifies the ticket type and gives back the ticket written:
```
(.venv) (base) shivena@Shivens-MacBook-Pro Remaining7-Discord-Bot % python -c "
import sys, asyncio, json
from dotenv import load_dotenv
load_dotenv()
from features.github_tickets import call_gemini
result = asyncio.run(call_gemini('the leaderboard command shows the wrong user at rank 1'))
print(json.dumps(result, indent=2))
"
{
  "type": "bug",
  "title": "Leaderboard command displays incorrect user at Rank 1",
  "body": "Bug: Leaderboard command displays incorrect user at Rank 1\n\n### Overview\nThe `leaderboard` command is currently displaying an incorrect user as holding the first rank, suggesting that the ranking logic or data retrieval is flawed.\n\n### Acceptance Criteria\nHow do we know it's done?\n- [ ] The `leaderboard` command accurately displays the user with the highest score/metric at Rank 1.\n- [ ] All users on the leaderboard are ranked correctly according to their scores/metrics.\n\n### Steps to Reproduce Bug\n- [ ] Execute the `leaderboard` command in a Discord channel.\n- [ ] Observe that the user listed at Rank 1 is not the user with the highest score/metric.\n- [ ] (Optional) Verify actual scores/metrics through administrative tools or database.\n\n### Impact\nUsers may lose trust in the bot's accuracy and fairness, especially for competitive features. This could lead to frustration and decreased engagement with the bot's ranking system.\n\n### Screenshots/Logs [if applicable]\nAttach screenshots, error logs, or any relevant artifacts.\n\n### Branch\n```\n-Bug\n```"
}
```

Part of #210 
Closes #215
