### PR TITLE
217-Feature add GitHub Issues API integration and wire up issue creation in on_message

### DIFF
--- a/features/github_tickets.py
+++ b/features/github_tickets.py
@@ -6,7 +6,11 @@ import aiohttp
 import discord
 from discord.ext import commands
 
+from features.config import GITHUB_REPO
+
 GEMINI_TOKEN = os.getenv("GEMINI_TOKEN")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/issues"
 GEMINI_API_URL = (
     "https://generativelanguage.googleapis.com/v1beta/models/"
     "gemini-2.5-flash:generateContent"
@@ -175,7 +179,70 @@ async def call_gemini(raw_text: str) -> dict:
     if result["type"] not in ("bug", "enhancement", "feature"):
         raise RuntimeError(f"Gemini returned invalid type: '{result['type']}'")
 
+    # Fix 1: Extract first line as title, body starts from ### Overview
+    body = result["body"]
+    lines = body.split("\n")
+    if lines and lines[0].strip().startswith(("Bug:", "Enhancement:", "Feature:")):
+        result["title"] = lines[0].strip().rstrip(".")
+        for i, line in enumerate(lines[1:], start=1):
+            if line.strip().startswith("### "):
+                body = "\n".join(lines[i:])
+                break
+
+    # Fix 3: Collapse double newlines between consecutive checklist items
+    body = re.sub(r"(- \[[ x]\] [^\n]+)\n\n(- \[[ x]\])", r"\1\n\2", body)
+    result["body"] = body
+
     return result
+
+
+async def create_github_issue(title: str, body: str, label: str) -> dict:
+    """Create a GitHub issue via the REST API."""
+    if not GITHUB_TOKEN:
+        raise RuntimeError("GITHUB_TOKEN environment variable is not set.")
+
+    headers = {
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            GITHUB_API_URL,
+            headers=headers,
+            json={"title": title, "body": body, "labels": [label]},
+        ) as resp:
+            if resp.status != 201:
+                error_text = await resp.text()
+                raise RuntimeError(
+                    f"GitHub API returned status {resp.status}: {error_text}"
+                )
+
+            data = await resp.json()
+
+    return {"number": data["number"], "html_url": data["html_url"]}
+
+
+async def update_github_issue(issue_number: int, body: str) -> None:
+    """Patch an existing GitHub issue to update its body."""
+    headers = {
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.patch(
+            f"{GITHUB_API_URL}/{issue_number}",
+            headers=headers,
+            json={"body": body},
+        ) as resp:
+            if resp.status != 200:
+                error_text = await resp.text()
+                raise RuntimeError(
+                    f"GitHub API PATCH returned status {resp.status}: {error_text}"
+                )
 
 
 class GitHubTickets(commands.Cog):
@@ -199,8 +266,24 @@ class GitHubTickets(commands.Cog):
             )
             return
 
-        # TODO: Pass raw_text to Gemini integration
-        await message.reply(f"Received: {raw_text}")
+        reply = await message.reply("Creating GitHub issue...")
+
+        ticket = await call_gemini(raw_text)
+
+        # Fix 2: Map type to label name
+        label_map = {"bug": "Bug", "enhancement": "Enhancement", "feature": "Feature"}
+        label = label_map[ticket["type"]]
+
+        issue = await create_github_issue(ticket["title"], ticket["body"], label)
+
+        # Fix 4: Patch the body to prepend issue number to branch field
+        branch = f"{issue['number']}-{label}"
+        updated_body = ticket["body"].replace(f"-{label}", branch)
+        await update_github_issue(issue["number"], updated_body)
+
+        await reply.edit(
+            content=f"Created issue #{issue['number']}: <{issue['html_url']}>\nBranch: `{branch}`"
+        )
 
 
 async def setup(bot):


### PR DESCRIPTION
### Changes
  - Add create_github_issue(title, body) that POSTs to the GitHub REST API and returns the issue number and html_url                                                       
  - Authenticate with GITHUB_TOKEN from .env via Authorization: Bearer header with required GitHub API headers                                                             
  - Raise a descriptive RuntimeError with status code and response body on non-201 responses                                                                               
  - Wire on_message to call call_gemini() then pass its output into create_github_issue() and reply with the issue link

### Screenshots
Calling the bot on discord:
<img width="1104" height="252" alt="image" src="https://github.com/user-attachments/assets/e7bf6fc0-a778-4a02-b8be-da296920b85a" />

The ticket created:
<img width="895" height="801" alt="image" src="https://github.com/user-attachments/assets/cf423509-36c4-46c2-bbc4-09ab2ee53a1e" />

Part of #210
Closes #217 