### PR TITLE
231-Bug update bot to reply with ping

### DIFF
--- a/features/github_tickets.py
+++ b/features/github_tickets.py
@@ -311,12 +311,15 @@ class GitHubTickets(commands.Cog):
         if not raw_text:
             await message.reply(
                 "@ me with a description of your bug, enhancement, or feature"
-                " and I'll create a GitHub issue."
+                " and I'll create a GitHub issue.",
+                mention_author=True,
             )
             return
 
         view = ConfirmView(raw_text, message.author.id)
-        reply = await message.reply("Create a GitHub issue?", view=view)
+        reply = await message.reply(
+            "Create a GitHub issue?", view=view, mention_author=True
+        )
         view.message = reply
 
 


### PR DESCRIPTION
### Changes                                                                                                                                                              
  * Fixed bot reply not pinging the user when responding to @mentions in `github_tickets.py`   

Part of #210 
Closes #231