### PR TITLE
258-Bug fix !hacked triggering on messages with trailing text

### DIFF
--- a/features/security.py
+++ b/features/security.py
@@ -159,6 +159,9 @@ class Security(commands.Cog):
         if not await self.has_security_permission(ctx):
             return
 
+        if ctx.message.content.strip() != "!hacked":
+            return
+
         if not ctx.message.reference:
             await ctx.send("❌ Reply to a message with `!hacked` to flag that user.")
             return


### PR DESCRIPTION
### Changes                                                                                                                                                              
  * Fixed `!hacked` text command not ignoring messages where the command is followed by additional text (e.g. `!hacked is a command we have`) 

Closes #258