### PR TITLE
277-Feature add /version slash command with embed display

### DIFF
--- a/features/general.py
+++ b/features/general.py
@@ -194,6 +194,14 @@ class General(commands.Cog):
         "BRT": "America/Sao_Paulo",
     }
 
+    @app_commands.command(name="version", description="View the bot's current version.")
+    async def version(self, interaction: discord.Interaction):
+        embed = discord.Embed(
+            description=f"🤖 R7 Bot is running\n# {BOT_VERSION}",
+            color=discord.Color.blurple(),
+        )
+        await interaction.response.send_message(embed=embed)
+
     @app_commands.command(
         name="convert-time",
         description="Convert a date and time to all Discord timestamp formats.",


### PR DESCRIPTION
### Changes                                                                                                                                                               
  * Added `/version` slash command that displays the bot's current version in an embed                                                                                      
 
### Screenshots
New Command:
<img width="329" height="170" alt="image" src="https://github.com/user-attachments/assets/a22b7464-cd8f-4d8e-9b22-2b631d3fc76a" />

                                                                                                                                                                           
  Closes #277