### PR TITLE
251-Enhancement add moderator identity to hacked command embed

### DIFF
--- a/features/security.py
+++ b/features/security.py
@@ -117,7 +117,11 @@ class Security(commands.Cog):
         # 7. Build Result Embed
         embed = discord.Embed(
             title="🚨 User Flagged as Hacked",
-            description=f"**Target:** {target_user.mention} (`{target_user.id}`)\n**Action:** 7-Day Timeout & Message Purge",
+            description=(
+                f"**Target:** {target_user.mention} (`{target_user.id}`)\n"
+                f"**Moderator:** {moderator.mention}\n"
+                f"**Action:** 7-Day Timeout & Message Purge"
+            ),
             color=discord.Color.dark_red(),
         )
         embed.add_field(name="Status", value=timeout_status, inline=False)


### PR DESCRIPTION
## Changes                                                                                                                                                               
  * Added moderator mention to the `/hacked` command embed for better action traceability in channel and moderator logs                                                     
                                                                                    
### Screenshots
New flagged hacked user embed has `Moderator`:
<img width="528" height="339" alt="image" src="https://github.com/user-attachments/assets/b1e18c6e-492c-4cce-b6a7-8473b9bbc204" />

                                                                                        
  Closes #251