### PR TITLE
299-Bug fix floating-point display in redemption ticket balance fields

### DIFF
--- a/features/economy.py
+++ b/features/economy.py
@@ -991,11 +991,13 @@ class Economy(commands.Cog):
             )
             ticket_embed.add_field(
                 name="Balance Before",
-                value=f"{balance_display_before:,} R7 tokens",
+                value=f"{int(round(balance_display_before)):,} R7 tokens",
                 inline=True,
             )
             ticket_embed.add_field(
-                name="Balance After", value=f"{balance_after:,} R7 tokens", inline=True
+                name="Balance After",
+                value=f"{int(round(balance_after)):,} R7 tokens",
+                inline=True,
             )
             await ch.send(embed=ticket_embed)
 


### PR DESCRIPTION
### Changes
  * Fixed `Balance Before` and `Balance After` fields in the redemption ticket embed to display whole-number token amounts instead of raw floats with floating-point
  precision artifacts

  Closes #299