### PR TITLE
296-Bug fix redeem ticket channel not pinging the redeeming user

### DIFF
--- a/features/economy.py
+++ b/features/economy.py
@@ -999,7 +999,7 @@ class Economy(commands.Cog):
                 value=f"{int(round(balance_after)):,} R7 tokens",
                 inline=True,
             )
-            await ch.send(embed=ticket_embed)
+            await ch.send(content=interaction.user.mention, embed=ticket_embed)
 
         except Exception as e:
             await add_item_token(user_id, item, quantity=1)


### PR DESCRIPTION
### Changes
  * Fixed `/redeem` command not pinging the user in the newly created redemption ticket channel — moved the user mention from the embed description to the message content so Discord delivers the notification

  Closes #296