### PR TITLE
199-Enhancement add translation embed capture to ticket transcripts

### DIFF
--- a/features/tourney/tourney_utils.py
+++ b/features/tourney/tourney_utils.py
@@ -492,6 +492,39 @@ async def close_ticket_via_command(ctx: commands.Context):
     )
 
 
+def _extract_translation_lines(
+    embeds: list[discord.Embed], timestamp: str
+) -> list[str]:
+    result = []
+    for embed in embeds:
+        title = embed.title or ""
+        fields = {f.name: f.value for f in embed.fields}
+        if title.startswith("🌐 Translated from"):
+            lang = title.removeprefix("🌐 Translated from ").strip()
+            original = fields.get("Original Message", "").removeprefix("> ").strip()
+            translation = fields.get("English Translation", "").strip("*").strip()
+            if original and translation:
+                result.append(
+                    f'[{timestamp}] R7 Bot#9997 ({lang} >> English): "{original}" >> "{translation}"'
+                )
+        elif title.startswith("🌐 Translated to"):
+            lang = title.removeprefix("🌐 Translated to ").strip()
+            original = fields.get("Original English", "").removeprefix("> ").strip()
+            translated = next(
+                (
+                    v.strip("*").strip()
+                    for k, v in fields.items()
+                    if k != "Original English"
+                ),
+                None,
+            )
+            if original and translated:
+                result.append(
+                    f'[{timestamp}] R7 Bot#9997 (English >> {lang}): "{original}" >> "{translated}"'
+                )
+    return result
+
+
 async def build_transcript_text(channel: discord.TextChannel) -> str:
     """Collect all messages in the channel into a plain-text transcript,
     with header info from the channel topic.
@@ -529,7 +562,12 @@ async def build_transcript_text(channel: discord.TextChannel) -> str:
             if content:
                 content += " "
             content += f"[Attachments: {attachment_list}]"
-        lines.append(f"[{timestamp}] {author}: {content}")
+
+        translation_lines = _extract_translation_lines(msg.embeds, timestamp)
+
+        if content or not translation_lines:
+            lines.append(f"[{timestamp}] {author}: {content}")
+        lines.extend(translation_lines)
 
     if len(lines) <= 4:  # only header, no messages
         lines.append("No messages in this ticket.")


### PR DESCRIPTION
### Changes
  * Added translation embed capture to ticket transcripts — `!t` replies now appear as `R7 Bot#9997 (Spanish >> English): "puedes ayudarme" >> "can you help me"` and
  `/translate` responses appear as `R7 Bot#9997 (English >> Spanish): "can you help me" >> "puedes ayudarme"`, with both the original and translated phrase shown inline

  ### Logs
Transcript with translation:
```
  Team: GT
  Match Number: 23
  Issue: Help me

  [2026-06-12 17:03] R7 Bot#9997 (1442024566124974080):
  [2026-06-12 17:03] R7 Bot#9997 (1442024566124974080): <@408419700729708545> 👇 Please read this:
  [2026-06-12 17:04] remainingdelta (408419700729708545): Puedes ayudarme
  [2026-06-12 17:04] remainingdelta (408419700729708545): !t
  [2026-06-12 17:04] R7 Bot#9997 (1442024566124974080):
  [2026-06-12 17:04] R7 Bot#9997 (Spanish >> English): "Puedes ayudarme" >> "can you help me"
  [2026-06-12 17:04] remainingdelta (408419700729708545): ok
  [2026-06-12 17:04] remainingdelta (408419700729708545): !c
  [2026-06-12 17:04] R7 Bot#9997 (1442024566124974080): Ticket closed by remainingdelta and moved to [CLOSED] Tourney Support Tickets.
```
  Closes #199