### PR TITLE
202-Bug fix bracket progress showing wrong round numbers

### DIFF
--- a/features/tourney/matcherino.py
+++ b/features/tourney/matcherino.py
@@ -555,6 +555,16 @@ def fetch_bracket_progress(url: str) -> dict:
         m["resolved_round"] = m.get("round") or m.get("roundNum") or 1
         real_matches.append(m)
 
+    # Normalize round numbers so the first real round is always Round 1.
+    # When participant count is <= half the bracket size, Matcherino gives every
+    # team a first-round BYE. After filtering those out, resolved_round starts
+    # at 2+, shifting every displayed round label up by one.
+    if real_matches:
+        min_round = min(m["resolved_round"] for m in real_matches)
+        if min_round > 1:
+            for m in real_matches:
+                m["resolved_round"] -= min_round - 1
+
     # Build visual numbering map (the numbers staff see on the bracket UI).
     # We keep this consistent with fetch_ticket_context: sort visible matches by API matchNum
     # and assign sequential visual numbers.


### PR DESCRIPTION
### Changes
  * Fixed bracket progress embed displaying round numbers off by one — when participant count is ≤ half the bracket size, Matcherino gives every team a first-round BYE, causing `resolved_round` to start at 2+ after BYE filtering. Round numbers are now normalized so the first real round always displays as Round 1.

  | Round (before) | Round (after) | Match numbers | Actual (Matcherino site) |
  |---|---|---|---|
  | Round 2 | Round 1 | 1–15 | Round 1 |
  | Round 3 | Round 2 | 16–47 | Round 2 |
  | Round 4 | Round 3 | 48–63 | Round 3 |
  | Round 5 | Round 4 | 64–71 | Round 4 |
  | Round 6 | Round 5 | 72–75 | Round 5 |
  | Round 7 | Round 6 | 76–77 | Round 6 |
  | Round 8 | Round 7 | 78–79 | Round 7 |

  *Verified against tournament 191034 (79 teams, 256-slot bracket).

  Closes #202