### PR TITLE
198-Bug improve match history to show pending matchups instead of hiding TBD slots

### DIFF
--- a/features/tourney/matcherino.py
+++ b/features/tourney/matcherino.py
@@ -291,6 +291,50 @@ def fetch_ticket_context(
             m["visualNum"] = i
             visual_match_map[i] = m
 
+        raw_to_visual = {
+            m.get("matchNum"): v_num for v_num, m in visual_match_map.items()
+        }
+
+        def resolve_name(entrant_dict, source_entry, depth=0):
+            name = get_team_info(entrant_dict)["name"]
+            if name not in ("TBD", "BYE"):
+                return name
+            if not source_entry or depth > 1:
+                return "TBD"
+            raw_src = source_entry.get("matchNum")
+            v_src = raw_to_visual.get(raw_src, raw_src)
+            src = visual_match_map.get(v_src)
+            if not src:
+                return f"Waiting on Match #{v_src}"
+            srcs = src.get("entrantSources") or []
+            a = resolve_name(src.get("entrantA"), srcs[0] if srcs else None, depth + 1)
+            b = resolve_name(
+                src.get("entrantB"), srcs[1] if len(srcs) > 1 else None, depth + 1
+            )
+            return f"Waiting on Match #{v_src} ({a} vs {b})"
+
+        def build_tbd_chain(source_entry):
+            if not source_entry:
+                return ["→ No source match information available"]
+            raw_src = source_entry.get("matchNum")
+            v_src = raw_to_visual.get(raw_src, raw_src)
+            src_match = visual_match_map.get(v_src)
+            if not src_match:
+                return [f"→ Waiting on Match #{v_src}"]
+            srcs = src_match.get("entrantSources") or []
+            a_name = resolve_name(
+                src_match.get("entrantA"), srcs[0] if srcs else None, depth=1
+            )
+            b_name = resolve_name(
+                src_match.get("entrantB"), srcs[1] if len(srcs) > 1 else None, depth=1
+            )
+            if "Waiting on" not in a_name and "Waiting on" not in b_name:
+                return [f"→ Match #{v_src}: {a_name} vs {b_name}"]
+            return [
+                f"→ Match #{v_src} [A]: {a_name}",
+                f"→ Match #{v_src} [B]: {b_name}",
+            ]
+
         current_match = visual_match_map.get(int(target_match_number))
 
         if not current_match:
@@ -300,6 +344,22 @@ def fetch_ticket_context(
 
         team_a = get_team_info(current_match.get("entrantA"))
         team_b = get_team_info(current_match.get("entrantB"))
+
+        sources = current_match.get("entrantSources") or []
+        team_a_is_tbd = team_a["name"] in ("TBD", "BYE")
+        team_b_is_tbd = team_b["name"] in ("TBD", "BYE")
+
+        if team_a_is_tbd:
+            src_a = sources[0] if sources else None
+            if src_a:
+                raw = src_a.get("matchNum")
+                team_a["name"] = f"Waiting on Match #{raw_to_visual.get(raw, raw)}"
+
+        if team_b_is_tbd:
+            src_b = sources[1] if len(sources) > 1 else None
+            if src_b:
+                raw = src_b.get("matchNum")
+                team_b["name"] = f"Waiting on Match #{raw_to_visual.get(raw, raw)}"
 
         match_status = current_match.get("status", "unknown")
 
@@ -335,8 +395,14 @@ def fetch_ticket_context(
             except Exception:
                 pass
 
-        team_a_history = []
-        team_b_history = []
+        team_a_history = (
+            build_tbd_chain(sources[0] if sources else None) if team_a_is_tbd else []
+        )
+        team_b_history = (
+            build_tbd_chain(sources[1] if len(sources) > 1 else None)
+            if team_b_is_tbd
+            else []
+        )
 
         for v_num, match in visual_match_map.items():
             if str(v_num) == str(target_match_number):
@@ -353,7 +419,18 @@ def fetch_ticket_context(
                 is_pos_a = t_a_past["name"] == team_a["name"]
                 opp_name = t_b_past["name"] if is_pos_a else t_a_past["name"]
 
-                if opp_name.upper() not in ["BYE", "TBD"]:
+                if opp_name.upper() == "TBD":
+                    h_srcs = match.get("entrantSources") or []
+                    opp_idx = 1 if is_pos_a else 0
+                    opp_src = h_srcs[opp_idx] if len(h_srcs) > opp_idx else None
+                    opp_dict = (
+                        match.get("entrantB") if is_pos_a else match.get("entrantA")
+                    )
+                    opp_label = resolve_name(opp_dict, opp_src)
+                    team_a_history.append(
+                        f"Match {v_num}: {team_a['name']} vs {opp_label}"
+                    )
+                elif opp_name.upper() != "BYE":
                     t_score = t_a_past["score"] if is_pos_a else t_b_past["score"]
                     o_score = t_b_past["score"] if is_pos_a else t_a_past["score"]
                     team_a_history.append(
@@ -368,7 +445,18 @@ def fetch_ticket_context(
                 is_pos_a = t_a_past["name"] == team_b["name"]
                 opp_name = t_b_past["name"] if is_pos_a else t_a_past["name"]
 
-                if opp_name.upper() not in ["BYE", "TBD"]:
+                if opp_name.upper() == "TBD":
+                    h_srcs = match.get("entrantSources") or []
+                    opp_idx = 1 if is_pos_a else 0
+                    opp_src = h_srcs[opp_idx] if len(h_srcs) > opp_idx else None
+                    opp_dict = (
+                        match.get("entrantB") if is_pos_a else match.get("entrantA")
+                    )
+                    opp_label = resolve_name(opp_dict, opp_src)
+                    team_b_history.append(
+                        f"Match {v_num}: {team_b['name']} vs {opp_label}"
+                    )
+                elif opp_name.upper() != "BYE":
                     t_score = t_a_past["score"] if is_pos_a else t_b_past["score"]
                     o_score = t_b_past["score"] if is_pos_a else t_a_past["score"]
                     team_b_history.append(

--- a/features/tourney/matcherino.py
+++ b/features/tourney/matcherino.py
@@ -295,6 +295,20 @@ def fetch_ticket_context(
             m.get("matchNum"): v_num for v_num, m in visual_match_map.items()
         }
 
+        def find_src(my_entrant, other_entrant, srcs, fallback_idx=0):
+            """Return the entrantSources entry for my_entrant by matching entrantId."""
+            my_id = (my_entrant or {}).get("entrantId", 0)
+            other_id = (other_entrant or {}).get("entrantId", 0)
+            if my_id != 0:
+                found = next((s for s in srcs if s.get("entrantId") == my_id), None)
+                if found:
+                    return found
+            if other_id != 0:
+                found = next((s for s in srcs if s.get("entrantId") != other_id), None)
+                if found:
+                    return found
+            return srcs[fallback_idx] if len(srcs) > fallback_idx else None
+
         def resolve_name(entrant_dict, source_entry, depth=0):
             name = get_team_info(entrant_dict)["name"]
             if name not in ("TBD", "BYE"):
@@ -307,10 +321,10 @@ def fetch_ticket_context(
             if not src:
                 return f"Waiting on Match #{v_src}"
             srcs = src.get("entrantSources") or []
-            a = resolve_name(src.get("entrantA"), srcs[0] if srcs else None, depth + 1)
-            b = resolve_name(
-                src.get("entrantB"), srcs[1] if len(srcs) > 1 else None, depth + 1
-            )
+            src_ea = find_src(src.get("entrantA"), src.get("entrantB"), srcs, 0)
+            src_eb = find_src(src.get("entrantB"), src.get("entrantA"), srcs, 1)
+            a = resolve_name(src.get("entrantA"), src_ea, depth + 1)
+            b = resolve_name(src.get("entrantB"), src_eb, depth + 1)
             return f"Waiting on Match #{v_src} ({a} vs {b})"
 
         def build_tbd_chain(source_entry):
@@ -322,12 +336,14 @@ def fetch_ticket_context(
             if not src_match:
                 return [f"→ Waiting on Match #{v_src}"]
             srcs = src_match.get("entrantSources") or []
-            a_name = resolve_name(
-                src_match.get("entrantA"), srcs[0] if srcs else None, depth=1
+            src_ea = find_src(
+                src_match.get("entrantA"), src_match.get("entrantB"), srcs, 0
             )
-            b_name = resolve_name(
-                src_match.get("entrantB"), srcs[1] if len(srcs) > 1 else None, depth=1
+            src_eb = find_src(
+                src_match.get("entrantB"), src_match.get("entrantA"), srcs, 1
             )
+            a_name = resolve_name(src_match.get("entrantA"), src_ea, depth=1)
+            b_name = resolve_name(src_match.get("entrantB"), src_eb, depth=1)
             if "Waiting on" not in a_name and "Waiting on" not in b_name:
                 return [f"→ Match #{v_src}: {a_name} vs {b_name}"]
             return [
@@ -350,13 +366,17 @@ def fetch_ticket_context(
         team_b_is_tbd = team_b["name"] in ("TBD", "BYE")
 
         if team_a_is_tbd:
-            src_a = sources[0] if sources else None
+            src_a = find_src(
+                current_match.get("entrantA"), current_match.get("entrantB"), sources, 0
+            )
             if src_a:
                 raw = src_a.get("matchNum")
                 team_a["name"] = f"Waiting on Match #{raw_to_visual.get(raw, raw)}"
 
         if team_b_is_tbd:
-            src_b = sources[1] if len(sources) > 1 else None
+            src_b = find_src(
+                current_match.get("entrantB"), current_match.get("entrantA"), sources, 1
+            )
             if src_b:
                 raw = src_b.get("matchNum")
                 team_b["name"] = f"Waiting on Match #{raw_to_visual.get(raw, raw)}"
@@ -396,10 +416,26 @@ def fetch_ticket_context(
                 pass
 
         team_a_history = (
-            build_tbd_chain(sources[0] if sources else None) if team_a_is_tbd else []
+            build_tbd_chain(
+                find_src(
+                    current_match.get("entrantA"),
+                    current_match.get("entrantB"),
+                    sources,
+                    0,
+                )
+            )
+            if team_a_is_tbd
+            else []
         )
         team_b_history = (
-            build_tbd_chain(sources[1] if len(sources) > 1 else None)
+            build_tbd_chain(
+                find_src(
+                    current_match.get("entrantB"),
+                    current_match.get("entrantA"),
+                    sources,
+                    1,
+                )
+            )
             if team_b_is_tbd
             else []
         )
@@ -421,11 +457,13 @@ def fetch_ticket_context(
 
                 if opp_name.upper() == "TBD":
                     h_srcs = match.get("entrantSources") or []
-                    opp_idx = 1 if is_pos_a else 0
-                    opp_src = h_srcs[opp_idx] if len(h_srcs) > opp_idx else None
                     opp_dict = (
                         match.get("entrantB") if is_pos_a else match.get("entrantA")
                     )
+                    my_dict = (
+                        match.get("entrantA") if is_pos_a else match.get("entrantB")
+                    )
+                    opp_src = find_src(opp_dict, my_dict, h_srcs)
                     opp_label = resolve_name(opp_dict, opp_src)
                     team_a_history.append(
                         f"Match {v_num}: {team_a['name']} vs {opp_label}"
@@ -447,11 +485,13 @@ def fetch_ticket_context(
 
                 if opp_name.upper() == "TBD":
                     h_srcs = match.get("entrantSources") or []
-                    opp_idx = 1 if is_pos_a else 0
-                    opp_src = h_srcs[opp_idx] if len(h_srcs) > opp_idx else None
                     opp_dict = (
                         match.get("entrantB") if is_pos_a else match.get("entrantA")
                     )
+                    my_dict = (
+                        match.get("entrantA") if is_pos_a else match.get("entrantB")
+                    )
+                    opp_src = find_src(opp_dict, my_dict, h_srcs)
                     opp_label = resolve_name(opp_dict, opp_src)
                     team_b_history.append(
                         f"Match {v_num}: {team_b['name']} vs {opp_label}"

--- a/features/tourney/matcherino.py
+++ b/features/tourney/matcherino.py
@@ -272,7 +272,7 @@ def fetch_ticket_context(
             if not entrant_dict:
                 return {"name": "TBD", "score": 0, "players": []}
             e_id = entrant_dict.get("entrantId", 0)
-            score = entrant_dict.get("score", 0)
+            score = entrant_dict.get("score") or 0
             info = entrant_map.get(e_id, {"name": "TBD", "players": []})
             return {"name": info["name"], "score": score, "players": info["players"]}
 
@@ -325,6 +325,10 @@ def fetch_ticket_context(
             src_eb = find_src(src.get("entrantB"), src.get("entrantA"), srcs, 1)
             a = resolve_name(src.get("entrantA"), src_ea, depth + 1)
             b = resolve_name(src.get("entrantB"), src_eb, depth + 1)
+            if "Waiting on" not in a and "Waiting on" not in b:
+                a_score = src.get("entrantA", {}).get("score") or 0
+                b_score = src.get("entrantB", {}).get("score") or 0
+                return f"Waiting on Match #{v_src} ({a} {a_score} - {b_score} {b})"
             return f"Waiting on Match #{v_src} ({a} vs {b})"
 
         def build_tbd_chain(source_entry):
@@ -345,7 +349,9 @@ def fetch_ticket_context(
             a_name = resolve_name(src_match.get("entrantA"), src_ea, depth=1)
             b_name = resolve_name(src_match.get("entrantB"), src_eb, depth=1)
             if "Waiting on" not in a_name and "Waiting on" not in b_name:
-                return [f"→ Match #{v_src}: {a_name} vs {b_name}"]
+                a_score = src_match.get("entrantA", {}).get("score") or 0
+                b_score = src_match.get("entrantB", {}).get("score") or 0
+                return [f"→ Match #{v_src}: {a_name} {a_score} - {b_score} {b_name}"]
             return [
                 f"→ Match #{v_src} [A]: {a_name}",
                 f"→ Match #{v_src} [B]: {b_name}",
@@ -365,21 +371,36 @@ def fetch_ticket_context(
         team_a_is_tbd = team_a["name"] in ("TBD", "BYE")
         team_b_is_tbd = team_b["name"] in ("TBD", "BYE")
 
+        def tbd_label(src_entry):
+            if not src_entry:
+                return "TBD"
+            raw = src_entry.get("matchNum")
+            v = raw_to_visual.get(raw, raw)
+            src_m = visual_match_map.get(v)
+            if not src_m:
+                return f"Waiting on Match #{v}"
+            srcs_m = src_m.get("entrantSources") or []
+            src_mea = find_src(src_m.get("entrantA"), src_m.get("entrantB"), srcs_m, 0)
+            src_meb = find_src(src_m.get("entrantB"), src_m.get("entrantA"), srcs_m, 1)
+            a_name = resolve_name(src_m.get("entrantA"), src_mea)
+            b_name = resolve_name(src_m.get("entrantB"), src_meb)
+            a_sc = src_m.get("entrantA", {}).get("score") or 0
+            b_sc = src_m.get("entrantB", {}).get("score") or 0
+            return f"Waiting on Match #{v} [{a_name} {a_sc} - {b_sc} {b_name}]"
+
         if team_a_is_tbd:
             src_a = find_src(
                 current_match.get("entrantA"), current_match.get("entrantB"), sources, 0
             )
-            if src_a:
-                raw = src_a.get("matchNum")
-                team_a["name"] = f"Waiting on Match #{raw_to_visual.get(raw, raw)}"
+            team_a["name"] = tbd_label(src_a)
+            team_a["score"] = None
 
         if team_b_is_tbd:
             src_b = find_src(
                 current_match.get("entrantB"), current_match.get("entrantA"), sources, 1
             )
-            if src_b:
-                raw = src_b.get("matchNum")
-                team_b["name"] = f"Waiting on Match #{raw_to_visual.get(raw, raw)}"
+            team_b["name"] = tbd_label(src_b)
+            team_b["score"] = None
 
         match_status = current_match.get("status", "unknown")
 


### PR DESCRIPTION
 ### Changes
  * Fixed `fetch_ticket_context` to resolve TBD match slots using `entrantSources`, showing "Waiting on Match #X [TeamA score - score TeamB]" instead of hiding the entry
  entirely
  * Fixed `entrantSources` slot lookup to match by `entrantId` instead of positional index, preventing wrong match numbers from being displayed
  * Updated `/match-history` to pre-populate TBD team history with the source match chain and live score
  * Updated `/match-info` and ticket open embeds to display TBD team name with source match context and `Score: None`
  * Fixed `get_team_info` returning `None` instead of `0` for unplayed match scores

### Screenshots
Match Info:
<img width="543" height="261" alt="image" src="https://github.com/user-attachments/assets/3902a38c-9a64-4e4e-a197-a636177dc9e0" />

Match History:
<img width="364" height="278" alt="image" src="https://github.com/user-attachments/assets/f425ad39-6283-4faf-bc71-05f8eb437f38" />



Closes #198