### PR TITLE
184-Bug fix quest rewards to better incentivize harder quests

### DIFF
--- a/database/mongo.py
+++ b/database/mongo.py
@@ -675,25 +675,25 @@ async def add_hypercharge_to_user(user_id: str, brawler_id: str, hc_name: str):
 
 
 async def init_default_quests(default_quests_list):
-    """Ensures default quests exist in the DB (Run once)."""
+    """Upserts default quests into the DB, syncing rewards to code on every startup."""
     if db is None:
         return
-    # Check if quests already exist to avoid duplicates
-    if await db.quests.count_documents({}) == 0:
-        for q in default_quests_list:
-            # Matches your screenshot structure
-            await db.quests.insert_one(
-                {
-                    "name": q[0],
+    for q in default_quests_list:
+        await db.quests.update_one(
+            {"name": q[0]},
+            {
+                "$set": {
                     "description": q[1],
                     "reward_tokens": q[2],
                     "reward_exp": q[3],
-                    "target_count": q[4],  # Matches screenshot
-                    "quest_type": q[5],  # Matches screenshot
+                    "target_count": q[4],
+                    "quest_type": q[5],
                     "is_active": True,
                 }
-            )
-        print("✅ Default Quests Initialized in MongoDB")
+            },
+            upsert=True,
+        )
+    print("✅ Default Quests synced to MongoDB")
 
 
 async def get_active_quest(user_id: str, q_type: str):

--- a/features/quests.py
+++ b/features/quests.py
@@ -25,20 +25,20 @@ from database.mongo import (
 DEFAULT_QUESTS = [
     # Daily Quests
     # Name | Desc | Tokens | XP | Target | Type
-    ("Daily Chatter", "Send 80 messages today.", 50, 200, 80, "daily"),
-    ("Quick Convo", "Send 160 messages today.", 75, 250, 160, "daily"),
-    ("Engaged Today", "Send 240 messages today.", 100, 300, 240, "daily"),
+    ("Daily Chatter", "Send 80 messages today.", 50, 100, 80, "daily"),
+    ("Quick Convo", "Send 160 messages today.", 115, 200, 160, "daily"),
+    ("Engaged Today", "Send 240 messages today.", 250, 300, 240, "daily"),
     # Weekly Quests
-    ("Weekly Regular", "Send 500 messages this week.", 250, 1000, 500, "weekly"),
+    ("Weekly Regular", "Send 500 messages this week.", 225, 1000, 500, "weekly"),
     (
         "Consistent Contributor",
         "Send 750 messages this week.",
         400,
-        2500,
+        2000,
         750,
         "weekly",
     ),
-    ("Server Pillar", "Send 1000 messages this week.", 600, 3000, 1000, "weekly"),
+    ("Server Pillar", "Send 1000 messages this week.", 640, 3000, 1000, "weekly"),
 ]
 
 


### PR DESCRIPTION
### Changes
  - Updated `DEFAULT_QUESTS` in `quests.py` with rebalanced token and XP rewards that better incentivize harder quests over easier ones
  - Fixed `init_default_quests` in `mongo.py` to upsert by quest name on every startup instead of only inserting when the collection is empty, ensuring DB values always
  stay in sync with code
 
**Before**
  | Quest | Messages | Tokens | XP |
  |---|---|---|---|
  | Daily Chatter | 80 | 50 | 200 |
  | Quick Convo | 160 | 75 | 250 |
  | Engaged Today | 240 | 100 | 300 |
  | Weekly Regular | 500 | 250 | 1,000 |
  | Consistent Contributor | 750 | 400 | 2,500 |
  | Server Pillar | 1,000 | 600 | 3,000 |
  
  **After**
  | Quest | Messages | Tokens | XP |
  |---|---|---|---|
  | Daily Chatter | 80 | 50 | 100 |
  | Quick Convo | 160 | 115 | 200 |
  | Engaged Today | 240 | 250 | 300 |
  | Weekly Regular | 500 | 225 | 1,000 |
  | Consistent Contributor | 750 | 400 | 2,000 |
  | Server Pillar | 1,000 | 640 | 3,000 |

Closes #184