### PR TITLE
333-Enhancement remove !lock and !unlock commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Every user always has **4 active quests** — one daily and one weekly per categ
 - **Ticket Panels:** `/tourney-panel` (live) and `/pre-tourney-panel` (pre-tourney) post interactive open buttons.
 - **Ticket Operations:**
   - `!close` / `!c` — close a ticket.
-  - `!lock` / `!unlock` — lock/unlock a ticket channel.
   - `!delete` / `!del` — delete ticket with transcript.
   - `!reopen` — reopen a closed ticket.
   - `/add <user>` / `/remove <user>` — manage ticket access.

--- a/docs/TOURNEY_OVERVIEW.md
+++ b/docs/TOURNEY_OVERVIEW.md
@@ -17,7 +17,7 @@ The tournament system orchestrates the full lifecycle of a Brawl Stars tournamen
    re.search(r"matcherino\.com/supercell/tournaments/(\d+)", content)
    ```
    and saves the ID to the active session. If not found, posts a warning telling staff to set it manually with `/set-matcherino`.
-5. **Locks** `OTHER_TICKET_CHANNEL_ID` from members (6-hour auto-reopen timer starts)
+5. **Locks** `OTHER_TICKET_CHANNEL_ID` from members via the internal `lock_command()` helper (6-hour auto-reopen timer starts)
 6. **SA region mode** (`!starttourney sa`): locks the Spanish support channel (`SPANISH_CHANNEL_ID`) and posts a redirect embed in Spanish pointing members to the main tourney support channel
 7. **Main tourney support channel** (`TOURNEY_SUPPORT_CHANNEL_ID`):
    - Sets permissions: `@everyone` can view but not send; staff roles can send

--- a/docs/TOURNEY_TICKETS.md
+++ b/docs/TOURNEY_TICKETS.md
@@ -179,4 +179,4 @@ Both wrap back to 1 after 999. `reset_ticket_counter()` is called during `!start
 ## Source Files
 - `features/tourney/tourney_utils.py` — all ticket lifecycle logic
 - `features/tourney/tourney_views.py` — UI components (buttons, modals)
-- `features/tourney/tourney_commands.py` — `!close`, `!delete`, `!reopen`, `!lock`, `!unlock`
+- `features/tourney/tourney_commands.py` — `!close`, `!delete`, `!reopen`

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -1192,7 +1192,6 @@ def setup_tourney_commands(bot: commands.Bot):
 
         await close_ticket_via_command(ctx)
 
-    @bot.command(name="lock")
     async def lock_command(ctx: commands.Context):
         """Temporarily lock the OTHER ticket channel from members."""
         if not isinstance(ctx.author, discord.Member) or not is_staff(ctx.author):
@@ -1253,12 +1252,8 @@ def setup_tourney_commands(bot: commands.Bot):
         task = asyncio.create_task(auto_reopen())
         lock_tasks[channel.id] = task
 
-    @bot.command(name="unlock")
     async def unlock_command(ctx: commands.Context):
-        """
-        Manually unlock the general support channel (Legacy feature).
-        Previously named !reopen.
-        """
+        """Unlock the general support channel. Called internally by !endtourney."""
         if not isinstance(ctx.author, discord.Member) or not is_staff(ctx.author):
             await ctx.reply("You don't have permission to unlock the ticket channel.")
             return
@@ -1315,7 +1310,7 @@ def setup_tourney_commands(bot: commands.Bot):
             await reopen_ticket_via_command(ctx)
         else:
             await ctx.reply(
-                "⚠️ This command is for reopening **Closed Tourney Tickets**.\nTo unlock the main support channel, use `!unlock`."
+                "⚠️ This command is for reopening **Closed Tourney Tickets**."
             )
 
     @bot.command(name="starttourney")
@@ -2566,7 +2561,6 @@ def setup_tourney_commands(bot: commands.Bot):
             "`!endtourney` - Closes all active tickets, generates staff stats, posts the Pre-Tourney panel, and unlocks general support.\n"
             "`/tourney-panel` - Post the live tourney support button.\n"
             "`/pre-tourney-panel` - Post the pre-tourney support button.\n"
-            "`!lock` / `!unlock` - Manually close or open the general server support channel.\n"
             "`/tourney-test-mode` - Toggle 100-ticket limit and 0.1s cooldown for testing."
         )
         embed.add_field(name="⚙️ Session Management", value=session_text, inline=False)


### PR DESCRIPTION
### Changes
  - Removed `@bot.command` registration for `!lock` and `!unlock`; both functions remain as internal helpers called by `!starttourney` and `!endtourney`
  - Updated README, docs, and help embed to remove references to these commands
  
Closes #333