### PR TITLE
341-Feature add scam image detection system

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Remaining7-Discord-Bot/
 │   ├── economy.py                   # R7 Tokens, shop, daily, leveling, leaderboards
 │   ├── quests.py                    # Daily & weekly quest system
 │   ├── security.py                  # Hacked protocol (timeout, purge, flag)
+│   ├── scam_detection.py            # Scam image detection (MD5/pHash/ORB blacklist)
 │   ├── event.py                     # Event channel cleanup & reward payouts
 │   ├── general.py                   # /help, /mod-help, /admin-help, /version, /convert-time
 │   ├── translation.py               # !t prefix & /translate slash command (55 languages)
@@ -181,6 +182,16 @@ Every user always has **4 active quests** — one daily and one weekly per categ
 - `/unhacked <user>` — remove flag and timeout.
 - `/hacked-list` — view all currently flagged users.
 - Logs to moderator logs channel. Prevents targeting equal/higher role members.
+
+### Scam Image Detection
+- Automatically scans every image attachment against a MongoDB blacklist using three matchers: MD5 (identical files), pHash (re-compressed/resized copies), and ORB (cropped variants).
+- On a match: deletes the message, purges other copies of the image across all channels (30-min lookback), applies a 10-minute precautionary timeout, and sends a mod alert with the image and action buttons.
+- **Confirm Hacked** button — upgrades to a 7-day timeout, flags the user in the hacked DB, and DMs them. **False Positive** button — removes the timeout.
+- `!scam-add` (reply or attach) — add image(s) to the blacklist.
+- `!scam-remove <md5> [md5 ...]` — remove entries by MD5 prefix.
+- `!scam-list` — view all blacklisted images.
+- `!scam-rename <md5> <name>` — give an entry a readable name.
+- `!scam-test` (reply or attach) — dry-run detection with match distances, no action taken.
 
 ### Translation
 - `!t [language]` / `!translate [language]` — reply to a message to translate it to English.

--- a/database/mongo.py
+++ b/database/mongo.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import re
 import uuid
 import motor.motor_asyncio
 import certifi
@@ -308,6 +309,65 @@ async def get_hacked_users():
 async def remove_hacked_user(user_id: str):
     """Removes the hacked tag (e.g., after they recover account)."""
     await db.hacked_users.delete_one({"_id": user_id})
+
+
+# --- SCAM IMAGE BLACKLIST ---
+
+
+async def add_scam_image(filename: str, data: bytes, md5: str):
+    # _id is the MD5 hash so two different images with the same filename
+    # are stored as separate documents rather than overwriting each other.
+    await db.scam_images.update_one(
+        {"_id": md5},
+        {"$set": {"filename": filename, "data": data, "md5": md5}},
+        upsert=True,
+    )
+
+
+async def get_scam_images(include_data: bool = True):
+    # scam-list only needs filenames/hashes — skip the binary blobs there.
+    projection = None if include_data else {"data": 0}
+    cursor = db.scam_images.find({}, projection)
+    return await cursor.to_list(length=None)
+
+
+async def remove_scam_image(md5_prefix: str) -> int:
+    result = await db.scam_images.delete_many(
+        {"md5": {"$regex": f"^{re.escape(md5_prefix)}"}}
+    )
+    return result.deleted_count
+
+
+async def rename_scam_image(md5_prefix: str, new_filename: str) -> bool:
+    result = await db.scam_images.update_one(
+        {"md5": {"$regex": f"^{re.escape(md5_prefix)}"}},
+        {"$set": {"filename": new_filename}},
+    )
+    return result.matched_count > 0
+
+
+async def ensure_scam_lock_ttl_index():
+    """TTL index so detection locks auto-expire ~60s after creation.
+    Without this, a user+image lock lives forever and re-posts of the
+    same scam image by the same user would be silently ignored.
+    """
+    await db.scam_detection_locks.create_index("ts", expireAfterSeconds=60)
+
+
+async def acquire_scam_detection_lock(author_id: int, image_md5: str) -> bool:
+    """Atomically claim a detection slot for (author, image).
+    Returns True if this caller claimed it (should proceed).
+    Returns False if another handler already claimed it (should skip).
+    Lock expires after 60 seconds via TTL index on 'ts'.
+    """
+    key = f"{author_id}:{image_md5}"
+    result = await db.scam_detection_locks.find_one_and_update(
+        {"_id": key},
+        {"$setOnInsert": {"_id": key, "ts": datetime.utcnow()}},
+        upsert=True,
+        return_document=False,
+    )
+    return result is None  # None means doc didn't exist before — we claimed it
 
 
 # --- PAYOUT / ADMIN COMPENSATION HELPERS ---

--- a/docs/SCAM_DETECTION.md
+++ b/docs/SCAM_DETECTION.md
@@ -1,0 +1,97 @@
+# Scam Image Detection
+
+## Overview
+Compromised accounts spam the same scam screenshot (fake Nitro giveaways, phishing "free skins" images) across many channels at once. `features/scam_detection.py` scans every image attachment posted in the server against a MongoDB blacklist and reacts automatically: delete the message, purge other copies across channels, apply a short precautionary timeout, and alert moderators with Confirm/Dismiss buttons.
+
+It complements the Hacked System (`docs/HACKED_SYSTEM.md`) — detection is automatic here, while the heavy action (7-day timeout + DB flag + DM) only happens after a mod clicks **Confirm Hacked**.
+
+---
+
+## Detection Pipeline
+
+Each incoming image runs through three matchers in order (cheapest first), inside a `ThreadPoolExecutor` so CPU work never blocks the event loop:
+
+| Matcher | Catches | Threshold |
+|---|---|---|
+| **MD5** | Byte-identical re-uploads | Exact match |
+| **pHash** (64-bit DCT perceptual hash) | Re-compressed, resized, slightly edited copies | Hamming distance ≤ `PHASH_MATCH_THRESHOLD` (10) |
+| **ORB** (OpenCV feature matching) | Cropped variants | ≥ `ORB_MATCH_THRESHOLD` (15) keypoints at distance < `_ORB_DISTANCE_CUTOFF` (20) |
+
+Threshold tuning history:
+- pHash alone misses crops (a crop of a blacklisted image measured distance 21/64 — well above 10). ORB exists specifically for crops.
+- ORB at loose settings (25 keypoints @ distance 50) matched *everything* and deleted innocent images. The current tight cutoff (distance < 20) keeps only near-exact feature matches.
+- Raise `PHASH_MATCH_THRESHOLD` cautiously — 10 already allows minor edits; much higher starts matching unrelated screenshots with similar layouts.
+
+The pHash/ORB indexes are built in memory at cog load (`_reload_index()`) from the `scam_images` collection and hot-reloaded after every `!scam-add` / `!scam-remove` / `!scam-rename`.
+
+---
+
+## `on_message` Flow
+
+1. Skip bots, DMs, messages older than 10s (prevents re-processing on reconnect backfill), and anything starting with `!scam` (otherwise `!scam-add`/`!scam-test` with a blacklisted image attached would delete the mod's own command message and time them out).
+2. For each allowed attachment (`.png .jpg .jpeg .webp`): in-memory dedup check on `(author_id, filename, size)`, then download via the shared `aiohttp` session, then run the detection pipeline in the executor.
+3. On match, claim the **atomic detection lock** (see below). The lock loser still **deletes its copy of the message** but skips the alert/timeout/purge.
+4. Lock winner: delete the message → purge other copies across all channels/threads (`_PURGE_LOOKBACK_MINUTES = 30`, newest-first, MD5-verified by size pre-filter then download) → 10-minute timeout → mod alert to `MODERATOR_LOGS_CHANNEL_ID` with the image re-uploaded (so it survives the deletion) and a `ScamAlertView`.
+
+### Duplicate-Alert Prevention (the hard-won part)
+When the same image lands in 5 channels simultaneously, 5 `on_message` coroutines race. In-memory sets alone do **not** fix this reliably (tried twice — coroutine interleaving and key-expiry races both produced duplicate alerts). The working solution is a MongoDB atomic lock:
+
+```python
+acquire_scam_detection_lock(author_id, image_md5)
+# find_one_and_update with $setOnInsert + upsert — only one caller gets None back
+```
+
+Locks live in `scam_detection_locks` and expire via a **TTL index on `ts` (60s)**, created at cog load by `ensure_scam_lock_ttl_index()`. Without that index locks never expire and re-posts of the same image by the same user are ignored forever. Mongo's TTL monitor runs every ~60s, so real expiry is 60–120s.
+
+---
+
+## `ScamAlertView` Buttons
+
+Both buttons gate on the Security cog's `has_security_permission()` (Admin or Mod role).
+
+- **🚨 Confirm Hacked** — role-hierarchy guard, upgrade to 7-day timeout, `add_hacked_user()` DB flag, DM the user (same wording as the hacked protocol), edit the alert to a dark-red "Confirmed" embed, disable buttons.
+- **✅ False Positive** — remove the 10-minute timeout, edit the alert to a green "Dismissed" embed, disable buttons.
+
+**Known limitation:** the view is `timeout=None` but not a *persistent* view — buttons stop working after a bot restart. Pending alerts across a deploy must be handled with `/hacked`/`/unhacked` manually. Fixing this requires a `discord.ui.DynamicItem` refactor with the target user ID in the `custom_id`.
+
+---
+
+## Commands
+
+All commands require the Admin or Moderator role (via Security cog's `has_security_permission()`).
+
+| Command | Behavior |
+|---|---|
+| `!scam-add` | Reply to a message with an image, or attach image(s) directly. Downloads, stores in `scam_images` (max 15MB — Mongo doc limit), hot-reloads index. |
+| `!scam-remove <md5> [md5 ...]` | Removes entries by MD5 prefix. Accepts multiple prefixes; reports removed vs. not-found per prefix; reloads index once. |
+| `!scam-list` | Lists `filename — md5[:8]` for every entry (fetches without binary data). |
+| `!scam-rename <md5_prefix> <new name...>` | Renames **one** matching entry (use a unique prefix). Multi-word names allowed. |
+| `!scam-test` | Dry run — reply/attach like `!scam-add`. Reports match/no-match plus closest pHash distance and best ORB keypoint count. No action taken. |
+
+---
+
+## Database
+
+### `scam_images`
+```js
+{
+  _id: "<md5>",        // MD5 as _id — two different images named image.png don't collide
+  filename: "fake nitro giveaway",
+  data: BinData(...),  // full image bytes (needed to rebuild indexes at startup)
+  md5: "<md5>"         // duplicated as a field so prefix-regex remove/rename works
+}
+```
+Early versions keyed on filename — two different images both named `image.png` overwrote each other. MD5 `_id` fixed that.
+
+### `scam_detection_locks`
+```js
+{ _id: "<author_id>:<image_md5>", ts: ISODate(...) }  // TTL-indexed, 60s
+```
+
+---
+
+## Dependencies
+`opencv-python-headless`, `numpy`, `aiohttp` (in requirements.txt). Headless OpenCV — no GUI libs needed on the host.
+
+## Bot Permissions Required
+Manage Messages (delete), Moderate Members (timeouts), Read Message History (cross-channel purge), Send Messages + Attach Files in the mod-logs channel. Bot's role must be above targets or timeout calls 403 (error 50013).

--- a/features/general.py
+++ b/features/general.py
@@ -114,6 +114,18 @@ class General(commands.Cog):
         )
         embed.add_field(name="🚨 Security Protocol", value=security_text, inline=False)
 
+        # Scam Image Detection
+        scam_text = (
+            "Images are auto-scanned against the scam blacklist — matches are deleted, "
+            "the poster gets a 10-min timeout, and an alert with Confirm/Dismiss buttons is posted in mod-logs.\n"
+            "`!scam-add` - Reply to an image (or attach one) to blacklist it.\n"
+            "`!scam-remove <md5> [md5 ...]` - Remove entries by MD5 prefix.\n"
+            "`!scam-list` - View all blacklisted images.\n"
+            "`!scam-rename <md5> <name>` - Give an entry a readable name.\n"
+            "`!scam-test` - Dry-run detection on an image (no action taken)."
+        )
+        embed.add_field(name="🖼️ Scam Image Detection", value=scam_text, inline=False)
+
         # Server Tools
         tools_text = (
             "`/set-count <number>` - Manually set the current count in the counting channel.\n"

--- a/features/scam_detection.py
+++ b/features/scam_detection.py
@@ -1,0 +1,773 @@
+import asyncio
+import hashlib
+import io
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+
+import aiohttp
+import cv2
+import discord
+import numpy as np
+from discord.ext import commands
+
+from database.mongo import (
+    acquire_scam_detection_lock,
+    add_hacked_user,
+    add_scam_image,
+    ensure_scam_lock_ttl_index,
+    get_scam_images,
+    remove_scam_image,
+    rename_scam_image,
+)
+from features.config import MODERATOR_LOGS_CHANNEL_ID
+
+# pHash: max Hamming distance (out of 64 bits) to count as a match.
+# 0 = identical, <=5 = same image different compression, <=10 = minor resize/edit.
+PHASH_MATCH_THRESHOLD = 10
+
+# ORB: catches cropped/rotated variants. False positives only delete one message
+# now (no auto hacked-protocol), so threshold can be lower.
+ORB_MATCH_THRESHOLD = 15
+_ORB_DISTANCE_CUTOFF = 20
+
+# How far back to scan other channels for the same image after detection.
+_PURGE_LOOKBACK_MINUTES = 30
+
+_ALLOWED_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp")
+
+# MongoDB documents cap at 16MB — reject blacklist additions above this.
+_MAX_BLACKLIST_IMAGE_BYTES = 15 * 1024 * 1024
+
+
+def _compute_phash(img_gray: np.ndarray) -> int:
+    small = cv2.resize(img_gray, (32, 32), interpolation=cv2.INTER_AREA).astype(
+        np.float32
+    )
+    dct = cv2.dct(small)
+    dct_low = dct[:8, :8].flatten()
+    mean = dct_low.mean()
+    bits = (dct_low > mean).astype(np.uint8)
+    result = 0
+    for bit in bits:
+        result = (result << 1) | int(bit)
+    return result
+
+
+def _phash_distance(h1: int, h2: int) -> int:
+    return bin(h1 ^ h2).count("1")
+
+
+def _compute_features(image_bytes: bytes) -> tuple:
+    arr = np.frombuffer(image_bytes, np.uint8)
+    img = cv2.imdecode(arr, cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        return None, None
+    phash = _compute_phash(img)
+    orb = cv2.ORB_create()
+    _, desc = orb.detectAndCompute(img, None)
+    return phash, desc
+
+
+def _sync_check_image(
+    image_bytes: bytes,
+    md5_set: set,
+    phash_index: list,
+    orb_index: list,
+) -> tuple[bool, str | None]:
+    arr = np.frombuffer(image_bytes, np.uint8)
+    img = cv2.imdecode(arr, cv2.IMREAD_GRAYSCALE)
+
+    md5 = hashlib.md5(image_bytes).hexdigest()
+    if md5 in md5_set:
+        return True, "MD5"
+
+    if img is None:
+        return False, None
+
+    query_phash = _compute_phash(img)
+    for filename, ref_phash in phash_index:
+        dist = _phash_distance(query_phash, ref_phash)
+        if dist <= PHASH_MATCH_THRESHOLD:
+            return True, f"pHash ({filename}, dist={dist})"
+
+    orb = cv2.ORB_create()
+    _, query_desc = orb.detectAndCompute(img, None)
+    if query_desc is not None and len(query_desc) > 0 and orb_index:
+        bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+        for filename, ref_desc in orb_index:
+            if ref_desc is None or len(ref_desc) == 0:
+                continue
+            matches = bf.match(query_desc, ref_desc)
+            good = [m for m in matches if m.distance < _ORB_DISTANCE_CUTOFF]
+            if len(good) >= ORB_MATCH_THRESHOLD:
+                return True, f"ORB ({filename}, {len(good)} keypoints)"
+
+    return False, None
+
+
+def _sync_check_image_verbose(
+    image_bytes: bytes,
+    md5_set: set,
+    phash_index: list,
+    orb_index: list,
+) -> tuple[bool, str | None, list[str]]:
+    arr = np.frombuffer(image_bytes, np.uint8)
+    img = cv2.imdecode(arr, cv2.IMREAD_GRAYSCALE)
+    details = []
+
+    md5 = hashlib.md5(image_bytes).hexdigest()
+    if md5 in md5_set:
+        return True, "MD5", [f"MD5 exact match: `{md5[:8]}`"]
+
+    if img is None:
+        return False, None, ["Could not decode image"]
+
+    query_phash = _compute_phash(img)
+    phash_results = []
+    for filename, ref_phash in phash_index:
+        dist = _phash_distance(query_phash, ref_phash)
+        phash_results.append((dist, filename))
+        if dist <= PHASH_MATCH_THRESHOLD:
+            return (
+                True,
+                f"pHash ({filename})",
+                [
+                    f"pHash match: `{filename}` distance **{dist}**/64 (threshold {PHASH_MATCH_THRESHOLD})"
+                ],
+            )
+    if phash_results:
+        best_dist, best_file = min(phash_results)
+        details.append(
+            f"pHash closest: `{best_file}` distance **{best_dist}**/64 (threshold {PHASH_MATCH_THRESHOLD})"
+        )
+    else:
+        details.append("pHash: no entries in blacklist")
+
+    orb = cv2.ORB_create()
+    _, query_desc = orb.detectAndCompute(img, None)
+    if query_desc is not None and len(query_desc) > 0 and orb_index:
+        bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+        best_count, best_orb_file = 0, None
+        for filename, ref_desc in orb_index:
+            if ref_desc is None or len(ref_desc) == 0:
+                continue
+            matches = bf.match(query_desc, ref_desc)
+            good = [m for m in matches if m.distance < _ORB_DISTANCE_CUTOFF]
+            if len(good) > best_count:
+                best_count, best_orb_file = len(good), filename
+        if best_orb_file:
+            details.append(
+                f"ORB closest: `{best_orb_file}` **{best_count}** keypoints (threshold {ORB_MATCH_THRESHOLD})"
+            )
+
+    return False, None, details
+
+
+def _is_allowed_image(filename: str) -> bool:
+    return filename.lower().endswith(_ALLOWED_EXTENSIONS)
+
+
+class ScamAlertView(discord.ui.View):
+    """Sent to mod-log when a scam image is detected. Mods confirm or dismiss."""
+
+    def __init__(self, target: discord.Member | discord.User, bot: commands.Bot):
+        super().__init__(timeout=None)
+        self.target = target
+        self.bot = bot
+        self._acted = False
+
+    def _security_cog(self):
+        return self.bot.cogs.get("Security")
+
+    async def _has_permission(self, interaction: discord.Interaction) -> bool:
+        security = self._security_cog()
+        if security:
+            return await security.has_security_permission(interaction)
+        return False
+
+    @discord.ui.button(
+        label="Confirm Hacked", style=discord.ButtonStyle.danger, emoji="🚨"
+    )
+    async def confirm(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        if not await self._has_permission(interaction):
+            await interaction.response.send_message(
+                "❌ Permission denied.", ephemeral=True
+            )
+            return
+
+        if self._acted:
+            await interaction.response.send_message(
+                "Already acted on this alert.", ephemeral=True
+            )
+            return
+        self._acted = True
+        await interaction.response.defer()
+
+        guild = interaction.guild
+        target = self.target
+
+        # Attempt to get Member (for timeout + role guard)
+        if isinstance(target, discord.User):
+            try:
+                target = await guild.fetch_member(target.id)
+            except Exception:
+                pass
+
+        # Role guard
+        if isinstance(target, discord.Member):
+            if target.top_role >= guild.me.top_role:
+                await interaction.followup.send(
+                    "❌ Cannot act — user has equal or higher role than the bot.",
+                    ephemeral=True,
+                )
+                self._acted = False
+                return
+
+        # Upgrade timeout from 10 minutes to 7 days
+        timeout_status = "⚠️ User not in server — timeout skipped"
+        if isinstance(target, discord.Member):
+            try:
+                await target.timeout(
+                    timedelta(days=7), reason="Security: Confirmed Scam Account"
+                )
+                timeout_status = "✅ Upgraded to 7-day timeout"
+            except Exception as e:
+                timeout_status = f"⚠️ Timeout failed: {e}"
+
+        # DB flag
+        await add_hacked_user(str(target.id))
+
+        # DM the user
+        try:
+            dm_embed = discord.Embed(
+                title="🚨 Account Flagged as Compromised",
+                description=(
+                    "Your account has been flagged as **hacked** on the **Remaining 7** server.\n\n"
+                    "You have been **timed out for 1 week** as a security measure.\n\n"
+                    "If you recover your account, please message <@408419700729708545> to be untimed out."
+                ),
+                color=discord.Color.dark_red(),
+            )
+            await target.send(embed=dm_embed)
+        except Exception:
+            pass
+
+        # Update the alert embed and disable buttons
+        confirmed_embed = discord.Embed(
+            title="🚨 Scam Detection — Confirmed",
+            description=(
+                f"**User:** {target.mention} (`{target.id}`)\n"
+                f"**Confirmed by:** {interaction.user.mention}\n"
+                f"**Timeout:** {timeout_status}\n"
+                f"User flagged in database and DMed."
+            ),
+            color=discord.Color.dark_red(),
+        )
+        for child in self.children:
+            child.disabled = True
+        await interaction.message.edit(embed=confirmed_embed, view=self)
+
+    @discord.ui.button(
+        label="False Positive", style=discord.ButtonStyle.secondary, emoji="✅"
+    )
+    async def dismiss(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        if not await self._has_permission(interaction):
+            await interaction.response.send_message(
+                "❌ Permission denied.", ephemeral=True
+            )
+            return
+
+        if self._acted:
+            await interaction.response.send_message(
+                "Already acted on this alert.", ephemeral=True
+            )
+            return
+        self._acted = True
+
+        # Remove the 10-minute precautionary timeout
+        timeout_removed = False
+        guild = interaction.guild
+        target = self.target
+        if isinstance(target, discord.User):
+            try:
+                target = await guild.fetch_member(target.id)
+            except Exception:
+                pass
+        if isinstance(target, discord.Member):
+            try:
+                await target.timeout(
+                    None, reason="Security: Scam alert dismissed as false positive"
+                )
+                timeout_removed = True
+            except Exception:
+                pass
+
+        timeout_note = (
+            "✅ 10-minute timeout removed."
+            if timeout_removed
+            else "⚠️ Could not remove timeout (user may have left)."
+        )
+
+        embed = discord.Embed(
+            title="✅ Scam Alert — Dismissed",
+            description=(
+                f"**User:** {self.target.mention} (`{self.target.id}`)\n"
+                f"**Dismissed by:** {interaction.user.mention}\n"
+                f"**Timeout:** {timeout_note}\n"
+                "Marked as false positive. No action taken."
+            ),
+            color=discord.Color.green(),
+        )
+        for child in self.children:
+            child.disabled = True
+        await interaction.response.edit_message(embed=embed, view=self)
+
+
+class ScamDetection(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self._md5_set: set = set()
+        self._phash_index: list = []
+        self._orb_index: list = []
+        self._executor = ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="scam_det"
+        )
+        # Tracks (author_id, filename, size) while a detection is in progress
+        # so concurrent on_message events for the same image don't send duplicate alerts.
+        self._processing: set = set()
+
+    async def cog_load(self):
+        # Shared HTTP session for all image downloads (detection, purge, commands).
+        self._session = aiohttp.ClientSession()
+        # TTL index so detection locks auto-expire; without it re-posts of the
+        # same image by the same user would stay locked out forever.
+        try:
+            await ensure_scam_lock_ttl_index()
+        except Exception as e:
+            print(f"⚠️ Scam Detection: could not create lock TTL index: {e}")
+        await self._reload_index()
+
+    async def cog_unload(self):
+        self._executor.shutdown(wait=False)
+        await self._session.close()
+
+    async def _download(self, url: str) -> bytes:
+        async with self._session.get(url) as resp:
+            return await resp.read()
+
+    async def _reload_index(self):
+        docs = await get_scam_images()
+        loop = asyncio.get_running_loop()
+
+        futures = [
+            loop.run_in_executor(self._executor, _compute_features, bytes(doc["data"]))
+            for doc in docs
+        ]
+        results = await asyncio.gather(*futures)
+
+        md5_set = set()
+        phash_index = []
+        orb_index = []
+        for doc, (phash, desc) in zip(docs, results):
+            md5_set.add(doc["md5"])
+            if phash is not None:
+                phash_index.append((doc["filename"], phash))
+            if desc is not None and len(desc) > 0:
+                orb_index.append((doc["filename"], desc))
+
+        self._md5_set = md5_set
+        self._phash_index = phash_index
+        self._orb_index = orb_index
+
+    async def _purge_scam_instances(
+        self,
+        guild: discord.Guild,
+        author_id: int,
+        image_md5: str,
+        image_size: int,
+        skip_message_id: int,
+    ) -> tuple[int, list[str]]:
+        """Delete all other instances of the same image (by MD5) across channels."""
+        deleted = 0
+        channels_hit = []
+        cutoff = discord.utils.utcnow() - timedelta(minutes=_PURGE_LOOKBACK_MINUTES)
+
+        all_channels = list(guild.text_channels) + list(guild.threads)
+        for channel in all_channels:
+            perms = channel.permissions_for(guild.me)
+            if not perms.read_message_history:
+                continue
+            try:
+                # newest-first so busy channels don't hide the most recent posts
+                # behind the 200-message limit
+                async for msg in channel.history(
+                    after=cutoff, oldest_first=False, limit=200
+                ):
+                    if msg.author.id != author_id or msg.id == skip_message_id:
+                        continue
+                    for att in msg.attachments:
+                        if not _is_allowed_image(att.filename):
+                            continue
+                        if att.size != image_size:
+                            continue
+                        try:
+                            data = await self._download(att.url)
+                            if hashlib.md5(data).hexdigest() == image_md5:
+                                await msg.delete()
+                                deleted += 1
+                                channels_hit.append(channel.mention)
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+            await asyncio.sleep(0.1)
+
+        return deleted, channels_hit
+
+    def _security_cog(self):
+        return self.bot.cogs.get("Security")
+
+    async def _has_permission(self, ctx: commands.Context) -> bool:
+        security = self._security_cog()
+        if security:
+            return await security.has_security_permission(ctx)
+        return False
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot or not message.guild:
+            return
+
+        # Skip scam management commands (!scam-add / !scam-test with an image
+        # attached) — otherwise the bot would delete the mod's own command
+        # message and time them out.
+        if message.content.startswith("!scam"):
+            return
+
+        age = (discord.utils.utcnow() - message.created_at).total_seconds()
+        if age > 10:
+            return
+
+        for attachment in message.attachments:
+            if not _is_allowed_image(attachment.filename):
+                continue
+
+            dedup_key = (message.author.id, attachment.filename, attachment.size)
+            if dedup_key in self._processing:
+                return
+            self._processing.add(dedup_key)
+
+            try:
+                image_bytes = await self._download(attachment.url)
+            except Exception:
+                self._processing.discard(dedup_key)
+                continue
+
+            md5_set = set(self._md5_set)
+            phash_index = list(self._phash_index)
+            orb_index = list(self._orb_index)
+            loop = asyncio.get_running_loop()
+
+            try:
+                matched, method = await loop.run_in_executor(
+                    self._executor,
+                    _sync_check_image,
+                    image_bytes,
+                    md5_set,
+                    phash_index,
+                    orb_index,
+                )
+            except Exception:
+                self._processing.discard(dedup_key)
+                continue
+
+            if not matched:
+                self._processing.discard(dedup_key)
+                continue
+
+            image_md5 = hashlib.md5(image_bytes).hexdigest()
+
+            # Atomic DB lock — prevents duplicate alerts across concurrent handlers
+            # and multiple bot instances. Skip if another handler claimed this first.
+            claimed = await acquire_scam_detection_lock(message.author.id, image_md5)
+            if not claimed:
+                # Another handler owns the alert/timeout, but this copy of the
+                # image still needs to go.
+                try:
+                    await message.delete()
+                except Exception:
+                    pass
+                self._processing.discard(dedup_key)
+                break
+
+            # Delete the flagged message
+            try:
+                await message.delete()
+            except Exception:
+                pass
+
+            # Delete other instances of the same image across channels
+            other_deleted, channels_hit = await self._purge_scam_instances(
+                message.guild,
+                message.author.id,
+                image_md5,
+                attachment.size,
+                message.id,
+            )
+
+            # Apply 10-minute precautionary timeout
+            timeout_status = "⚠️ Could not timeout (missing permissions or user left)"
+            target = message.author
+            if isinstance(target, discord.Member):
+                try:
+                    await target.timeout(
+                        timedelta(minutes=10),
+                        reason="Security: Suspected scam image — pending mod review",
+                    )
+                    timeout_status = "✅ Timed out for 10 minutes (pending review)"
+                except Exception:
+                    pass
+
+            # Build mod alert
+            total_deleted = 1 + other_deleted
+            channels_str = f"{message.channel.mention}" + (
+                f", {', '.join(channels_hit)}" if channels_hit else ""
+            )
+
+            alert_embed = discord.Embed(
+                title="🚨 Suspected Scam Image Detected",
+                description=(
+                    f"**User:** {message.author.mention} (`{message.author.id}`)\n"
+                    f"**Detected in:** {message.channel.mention}\n"
+                    f"**Method:** {method}\n"
+                    f"**Messages deleted:** {total_deleted} across {channels_str}\n"
+                    f"**Auto-timeout:** {timeout_status}"
+                ),
+                color=discord.Color.orange(),
+            )
+            alert_embed.set_footer(
+                text="Confirm to upgrade to 7-day timeout + DB flag + DM. Dismiss to remove the timeout."
+            )
+
+            # Re-upload the image so it persists in mod-log after original deletion
+            file = discord.File(io.BytesIO(image_bytes), filename=attachment.filename)
+            alert_embed.set_image(url=f"attachment://{attachment.filename}")
+
+            mod_log = self.bot.get_channel(MODERATOR_LOGS_CHANNEL_ID)
+            if mod_log:
+                view = ScamAlertView(target=message.author, bot=self.bot)
+                await mod_log.send(embed=alert_embed, file=file, view=view)
+
+            # Keep the key alive for 60 seconds so rapid re-posts of the same
+            # image by the same user don't send duplicate alerts.
+            asyncio.get_running_loop().call_later(
+                60, self._processing.discard, dedup_key
+            )
+            break
+
+    # --- MANAGEMENT COMMANDS ---
+
+    @commands.command(name="scam-add")
+    async def scam_add(self, ctx: commands.Context):
+        if not await self._has_permission(ctx):
+            return
+
+        target_msg = None
+        if ctx.message.reference:
+            try:
+                target_msg = await ctx.channel.fetch_message(
+                    ctx.message.reference.message_id
+                )
+            except Exception:
+                pass
+
+        attachments = []
+        if target_msg:
+            attachments = [
+                a for a in target_msg.attachments if _is_allowed_image(a.filename)
+            ]
+        if not attachments:
+            attachments = [
+                a for a in ctx.message.attachments if _is_allowed_image(a.filename)
+            ]
+
+        if not attachments:
+            await ctx.send(
+                "❌ Reply to a message containing an image, or attach an image directly."
+            )
+            return
+
+        added = []
+        for attachment in attachments:
+            if attachment.size > _MAX_BLACKLIST_IMAGE_BYTES:
+                await ctx.send(
+                    f"❌ `{attachment.filename}` is too large to store ({attachment.size // (1024 * 1024)}MB, max 15MB)."
+                )
+                continue
+
+            try:
+                image_bytes = await self._download(attachment.url)
+            except Exception as e:
+                await ctx.send(f"❌ Failed to download `{attachment.filename}`: {e}")
+                continue
+
+            md5 = hashlib.md5(image_bytes).hexdigest()
+            await add_scam_image(attachment.filename, image_bytes, md5)
+            added.append(attachment.filename)
+
+        if added:
+            await self._reload_index()
+            filenames = ", ".join(f"`{f}`" for f in added)
+            await ctx.send(
+                f"✅ Added {filenames} to the scam blacklist. Index hot-reloaded ({len(self._md5_set)} images)."
+            )
+
+    @commands.command(name="scam-remove")
+    async def scam_remove(self, ctx: commands.Context, *md5_prefixes: str):
+        if not await self._has_permission(ctx):
+            return
+
+        if not md5_prefixes:
+            await ctx.send(
+                "❌ Usage: `!scam-remove <md5_prefix> [md5_prefix ...]` — use `!scam-list` to see valid prefixes."
+            )
+            return
+
+        removed = []
+        not_found = []
+        for prefix in md5_prefixes:
+            deleted = await remove_scam_image(prefix)
+            if deleted:
+                removed.append(f"`{prefix}` ({deleted})")
+            else:
+                not_found.append(f"`{prefix}`")
+
+        if removed:
+            await self._reload_index()
+
+        lines = []
+        if removed:
+            lines.append(
+                f"✅ Removed: {', '.join(removed)}. Index hot-reloaded ({len(self._md5_set)} images)."
+            )
+        if not_found:
+            lines.append(
+                f"❌ No entry found for: {', '.join(not_found)}. Use `!scam-list` to see valid prefixes."
+            )
+        await ctx.send("\n".join(lines))
+
+    @commands.command(name="scam-list")
+    async def scam_list(self, ctx: commands.Context):
+        if not await self._has_permission(ctx):
+            return
+
+        docs = await get_scam_images(include_data=False)
+        if not docs:
+            await ctx.send("✅ Scam blacklist is empty.")
+            return
+
+        listing = "\n".join(
+            f"• `{doc['filename']}` — `{doc['md5'][:8]}`" for doc in docs
+        )
+        embed = discord.Embed(
+            title=f"🚨 Scam Image Blacklist — {len(docs)} image(s)",
+            description=listing,
+            color=discord.Color.dark_red(),
+        )
+        await ctx.send(embed=embed)
+
+    @commands.command(name="scam-rename")
+    async def scam_rename(
+        self, ctx: commands.Context, md5_prefix: str, *, new_name: str
+    ):
+        if not await self._has_permission(ctx):
+            return
+
+        found = await rename_scam_image(md5_prefix, new_name)
+        if found:
+            await self._reload_index()
+            await ctx.send(
+                f"✅ Renamed `{md5_prefix}` → `{new_name}`. Index hot-reloaded."
+            )
+        else:
+            await ctx.send(f"❌ No entry found with MD5 prefix `{md5_prefix}`.")
+
+    @commands.command(name="scam-test")
+    async def scam_test(self, ctx: commands.Context):
+        if not await self._has_permission(ctx):
+            return
+
+        target_msg = None
+        if ctx.message.reference:
+            try:
+                target_msg = await ctx.channel.fetch_message(
+                    ctx.message.reference.message_id
+                )
+            except Exception:
+                pass
+
+        attachments = []
+        if target_msg:
+            attachments = [
+                a for a in target_msg.attachments if _is_allowed_image(a.filename)
+            ]
+        if not attachments:
+            attachments = [
+                a for a in ctx.message.attachments if _is_allowed_image(a.filename)
+            ]
+
+        if not attachments:
+            await ctx.send(
+                "❌ Reply to a message containing an image, or attach an image directly."
+            )
+            return
+
+        status_msg = await ctx.send("⏳ Running detection dry-run...")
+        results = []
+
+        for attachment in attachments:
+            try:
+                image_bytes = await self._download(attachment.url)
+            except Exception as e:
+                results.append(f"`{attachment.filename}`: ❌ Download failed — {e}")
+                continue
+
+            md5_set = set(self._md5_set)
+            phash_index = list(self._phash_index)
+            orb_index = list(self._orb_index)
+            loop = asyncio.get_running_loop()
+
+            try:
+                matched, method, details = await loop.run_in_executor(
+                    self._executor,
+                    _sync_check_image_verbose,
+                    image_bytes,
+                    md5_set,
+                    phash_index,
+                    orb_index,
+                )
+            except Exception as e:
+                results.append(f"`{attachment.filename}`: ❌ Detection error — {e}")
+                continue
+
+            status = f"🚨 **MATCH** via {method}" if matched else "✅ No match"
+            detail_str = "\n  ".join(details)
+            results.append(f"`{attachment.filename}`: {status}\n  {detail_str}")
+
+        embed = discord.Embed(
+            title="🔍 Scam Detection — Dry Run",
+            description="\n\n".join(results),
+            color=discord.Color.orange(),
+        )
+        embed.set_footer(
+            text=f"pHash threshold: {PHASH_MATCH_THRESHOLD}/64 | ORB threshold: {ORB_MATCH_THRESHOLD} keypoints"
+        )
+        await status_msg.edit(content=None, embed=embed)
+
+
+async def setup(bot):
+    await bot.add_cog(ScamDetection(bot))

--- a/main.py
+++ b/main.py
@@ -53,6 +53,9 @@ async def on_ready():
         await bot.load_extension("features.security")
         print("✅ Loaded Feature: Security (Hacked)")
 
+        await bot.load_extension("features.scam_detection")
+        print("✅ Loaded Feature: Scam Detection")
+
         await bot.load_extension("features.brawl.commands")
         print("✅ Loaded Feature: Brawl (Drops)")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ requests-cache>=1.3
 beautifulsoup4>=4.14
 pytest>=7.0
 pytest-asyncio>=0.23
+opencv-python-headless>=4.8
+numpy>=1.26
+aiohttp>=3.9


### PR DESCRIPTION
### Changes
  * Added `features/scam_detection.py` cog that scans image attachments against a MongoDB blacklist using MD5 (exact), pHash
  (near-identical), and ORB (cropped variants) matching
  * Added auto-response on detection: deletes the message, purges other copies across channels (30-min lookback), applies a
  10-minute precautionary timeout, and sends a mod alert with the image attached
  * Added `Confirm Hacked` / `False Positive` buttons on mod alerts — confirm upgrades to a 7-day timeout, flags the user in the
  hacked DB, and DMs them; dismiss removes the timeout
  * Added management commands: `!scam-add`, `!scam-remove` (multiple prefixes), `!scam-list`, `!scam-rename`, `!scam-test`
  (dry-run with match distances)
  * Added scam image and detection-lock helpers to `database/mongo.py`, with an atomic per-user/image lock (60s TTL index) to
  prevent duplicate alerts across channels
  * Added `docs/SCAM_DETECTION.md` implementation guide and a Scam Image Detection section to the README
  * Updated `/mod-help` with the new scam detection commands
  * Added `opencv-python-headless`, `numpy`, and `aiohttp` to requirements.txt

<details>
<summary><h3>Screenshots</h3></summary>

`!scam-list`
<img width="337" height="232" alt="image" src="https://github.com/user-attachments/assets/66fc3c45-753d-4495-b1de-b74e31ff51fe" />

Warning in moderator logs:
<img width="434" height="489" alt=" Suspected Scam Image Detected" src="https://github.com/user-attachments/assets/741842c6-ee60-433a-90b5-3c9157aadd51" />




</details>

  Closes #341