### PR TITLE
338-Bug fix redemption budget to count pending tickets and add monthly queue

### DIFF
--- a/database/mongo.py
+++ b/database/mongo.py
@@ -4,6 +4,8 @@ import re
 import uuid
 import motor.motor_asyncio
 import certifi
+from bson import ObjectId
+from bson.errors import InvalidId
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -178,6 +180,44 @@ async def set_setting(key: str, value: str):
     if db is None:
         return
     await db.settings.update_one({"_id": key}, {"$set": {"value": value}}, upsert=True)
+
+
+# --- REDEMPTION QUEUE HELPERS ---
+
+
+async def add_redemption_queue_entry(
+    user_id: str, item: str, budget_usd: float
+) -> str | None:
+    """Queues a redemption for the next month. Returns the entry id."""
+    if db is None:
+        return None
+    result = await db.redemption_queue.insert_one(
+        {
+            "user_id": user_id,
+            "item": item,
+            "budget_usd": budget_usd,
+            "queued_at": datetime.utcnow(),
+        }
+    )
+    return str(result.inserted_id)
+
+
+async def get_redemption_queue() -> list[dict]:
+    """Returns all queued redemptions in FIFO order."""
+    if db is None:
+        return []
+    return await db.redemption_queue.find({}).sort("queued_at", 1).to_list(length=None)
+
+
+async def remove_redemption_queue_entry(entry_id: str) -> dict | None:
+    """Removes a queue entry by id. Returns the removed document, or None."""
+    if db is None:
+        return None
+    try:
+        oid = ObjectId(entry_id)
+    except (InvalidId, TypeError):
+        return None
+    return await db.redemption_queue.find_one_and_delete({"_id": oid})
 
 
 # --- COUNTING HELPERS ---

--- a/docs/ECONOMY_SHOP.md
+++ b/docs/ECONOMY_SHOP.md
@@ -1,7 +1,7 @@
 # Economy Shop
 
 ## Overview
-The shop lets members spend R7 Tokens on real-world rewards. Redemptions open a private ticket channel where staff fulfill the order. Each fulfilled redemption reduces the monthly USD budget. The budget auto-resets on the first of each calendar month by detecting a month key change.
+The shop lets members spend R7 Tokens on real-world rewards. Redemptions open a private ticket channel where staff fulfill the order. Each fulfilled redemption reduces the monthly USD budget. Open (pending) tickets also reserve budget: the available budget is `monthly_budget − spent − pending`, so redemptions can never collectively exceed the cap. Requests that don't fit the available budget can be queued for the next month instead. The budget auto-resets on the first of each calendar month by detecting a month key change.
 
 ---
 
@@ -37,13 +37,15 @@ REDEMPTION_BUDGET_COSTS = {
 
 ## Redemption Flow
 
-1. Member uses `/redeem` and selects an item
-2. Bot checks their token balance ≥ item price
-3. Deducts tokens immediately via `update_user_balance()`
-4. Creates a private ticket channel in `REDEMPTION_TICKET_CATEGORY_ID`:
+1. Member uses `/redeem` and selects an item they own
+2. Bot checks the **available budget**: `monthly_budget − manual_total_spent − pending`, where pending is computed by `_pending_redemptions_total()` — it scans the redemption category's channel topics and sums each ticket's `budget_usd` (falling back to `REDEMPTION_BUDGET_COSTS` if the topic value is missing/corrupt)
+3. If the item's USD cost exceeds the available budget, the member is offered the **redemption queue** (see below) instead of a ticket
+4. Otherwise the item is consumed and `create_redemption_ticket()` opens a private ticket channel in `REDEMPTION_TICKET_CATEGORY_ID`:
    - Channel topic: `redemption-opener:{user_id}|item:{item_key}|budget_usd:{cost}`
    - Opener gets full access + slash commands; Admin/Mod roles get full access
 5. Ticket shows the item requested, token cost deducted, and remaining balance
+
+The budget guard is re-checked once after the interaction defer, so two near-simultaneous redemptions can't both claim the last of the budget.
 
 ### Redemption Ticket Resolution
 
@@ -63,13 +65,14 @@ The budget cost on the "Reduce from budget" path is read from `budget_usd` in th
 
 ## Monthly Budget System
 
-The budget state lives in the `settings` MongoDB collection as three keys:
+The budget state lives in the `settings` MongoDB collection as these keys:
 
 | Key | Value |
 |-----|-------|
 | `budget_month_key` | `"YYYY-MM"` string for the current month |
 | `monthly_budget` | Total cap as float string (default `"50.00"`) |
 | `manual_total_spent` | Cumulative USD spent this month as float string |
+| `redemption_queue_processed_month` | `"YYYY-MM"` of the last month whose queue run completed |
 
 `ensure_monthly_budget_state()` runs on every budget interaction:
 ```python
@@ -83,7 +86,43 @@ if stored_key != current_key:
     # Also resets legacy per-item counters
 ```
 
-This is lazy reset — it only resets when something touches the budget, not on a scheduled task.
+This is lazy reset — it only resets when something touches the budget, not on a scheduled task. The hourly redemption-queue task (below) touches the budget at the start of every month, so in practice the reset also happens within an hour of rollover.
+
+---
+
+## Redemption Queue
+
+When a `/redeem` request exceeds the available budget, the member gets an ephemeral prompt with **Join queue for next month** / **Cancel** buttons (`RedemptionQueueConfirmView`). Confirming consumes the item token immediately and inserts a FIFO entry into the `redemption_queue` MongoDB collection:
+
+```python
+{
+  "user_id": "1234567890",   # str, matches users collection convention
+  "item": "brawl pass",      # SHOP_DATA key
+  "budget_usd": 10.0,        # snapshot at queue time (audit/display only)
+  "queued_at": datetime,     # FIFO sort key
+}
+```
+
+`budget_usd` is a snapshot for display; processing always recomputes the cost from `REDEMPTION_BUDGET_COSTS` so a cost change while queued uses the current value.
+
+### Processing
+
+`redemption_queue_task` is an hourly `tasks.loop` on the Economy cog. Each tick it compares `redemption_queue_processed_month` with the current month key; if they differ (new month, or bot was offline on the 1st), it runs `process_redemption_queue()` and stamps the key only on success (a failed run retries next hour).
+
+`process_redemption_queue()` walks the queue in FIFO order:
+- **Member left the server** → entry is dropped, the item's token price is refunded to their balance, and a note is posted to `REDEMPTION_TRANSCRIPT_CHANNEL_ID`.
+- **Cost > available budget** (recomputed every iteration, so tickets opened earlier in the run count as pending) → entry is skipped and carries over to the next month; cheaper later entries may still be fulfilled.
+- **Otherwise** → a ticket is created via `create_redemption_ticket()` (pinging the member) and the entry is removed — only after the channel is successfully created, so failures leave the entry queued.
+
+### Queue Commands
+
+| Command | Who | Notes |
+|---------|-----|-------|
+| `/redemption-queue` | Anyone | Your queued redemptions with overall FIFO position (ephemeral) |
+| `/redemption-queue-list` | Admin/Mod | Full queue with entry ids and estimated USD total |
+| `/redemption-queue-remove <entry_id>` | Admin/Mod | Removes an entry and returns the item to the user's inventory |
+
+`/check-budget` also shows the pending-ticket total and the queued-entry count/estimate.
 
 ---
 

--- a/features/economy.py
+++ b/features/economy.py
@@ -11,6 +11,7 @@ import asyncio
 from database.mongo import (
     get_user_balance,
     update_user_balance,
+    increment_user_balance,
     get_leveling_data,
     update_leveling_data,
     add_item_token,
@@ -23,6 +24,9 @@ from database.mongo import (
     get_user_rank,
     get_levels_page,
     get_user_level_rank,
+    add_redemption_queue_entry,
+    get_redemption_queue,
+    remove_redemption_queue_entry,
 )
 
 # --- CONFIGURATION ---
@@ -108,6 +112,20 @@ async def get_budget_totals() -> tuple[float, float, float]:
     return total_budget, total_spent, remaining
 
 
+async def get_effective_budget(
+    guild: discord.Guild | None,
+) -> tuple[float, float, float, float]:
+    """Budget totals with pending tickets counted.
+
+    Returns (total_budget, spent, pending_usd, available) where
+    available = total_budget - spent - pending_usd.
+    """
+    total_budget, total_spent, _ = await get_budget_totals()
+    pending_usd, _ = _pending_redemptions_total(guild)
+    available = total_budget - total_spent - pending_usd
+    return total_budget, total_spent, pending_usd, available
+
+
 async def add_budget_spent(amount: float) -> float:
     await ensure_monthly_budget_state()
     spent_str = await get_setting("manual_total_spent", "0.00")
@@ -145,6 +163,41 @@ def _extract_topic_value(topic: str | None, key: str) -> str | None:
     return None
 
 
+def _pending_redemptions_total(guild: discord.Guild | None) -> tuple[float, int]:
+    """Sum the budget cost of open redemption tickets. Returns (total_usd, count)."""
+    if guild is None:
+        return 0.0, 0
+    if (
+        not isinstance(REDEMPTION_TICKET_CATEGORY_ID, int)
+        or REDEMPTION_TICKET_CATEGORY_ID <= 0
+    ):
+        return 0.0, 0
+
+    category = guild.get_channel(REDEMPTION_TICKET_CATEGORY_ID)
+    if not isinstance(category, discord.CategoryChannel):
+        return 0.0, 0
+
+    total = 0.0
+    count = 0
+    for channel in category.text_channels:
+        if _extract_topic_value(channel.topic, "redemption-opener") is None:
+            continue
+        item = _extract_topic_value(channel.topic, "item") or ""
+        budget_raw = _extract_topic_value(channel.topic, "budget_usd")
+        try:
+            cost = (
+                float(budget_raw)
+                if budget_raw is not None
+                else _budget_cost_for_item(item)
+            )
+        except ValueError:
+            cost = _budget_cost_for_item(item)
+        if cost > 0:
+            total += cost
+            count += 1
+    return total, count
+
+
 def _is_redemption_staff(member: discord.abc.User | discord.Member) -> bool:
     if not isinstance(member, discord.Member):
         return False
@@ -160,6 +213,101 @@ def _is_redemption_ticket_channel(channel: discord.abc.GuildChannel | None) -> b
     ):
         return False
     return channel.category_id == REDEMPTION_TICKET_CATEGORY_ID
+
+
+def _redemption_instructions(item: str) -> str:
+    if "brawl pass" in item:
+        return "- Provide your in-game ID and a link to add you."
+    if "nitro" in item:
+        return "- Provide the Discord account you'd like the Nitro gifted to."
+    if "paypal" in item:
+        return "- Provide your PayPal email address."
+    if "shoutout" in item:
+        return "- Provide the message you want to be shouted out."
+    return "- Provide necessary details."
+
+
+async def _increment_redeem_counter(item: str) -> None:
+    tracking_keys = {
+        "brawl pass": "brawlpass_redeemed_count",
+        "brawl pass+": "brawlpass+_redeemed_count",
+        "nitro": "nitro_redeemed_count",
+        "paypal": "paypal_redeemed_count",
+        "shoutout": "shoutout_redeemed_count",
+    }
+    if item in tracking_keys:
+        key = tracking_keys[item]
+        current = int(await get_setting(key, "0"))
+        await set_setting(key, str(current + 1))
+
+
+async def create_redemption_ticket(
+    guild: discord.Guild,
+    member: discord.Member,
+    item: str,
+    budget_cost: float,
+) -> discord.TextChannel:
+    """Creates a redemption ticket channel with permissions, topic metadata,
+    and the opening embed. Does not consume item tokens."""
+    if (
+        not isinstance(REDEMPTION_TICKET_CATEGORY_ID, int)
+        or REDEMPTION_TICKET_CATEGORY_ID <= 0
+    ):
+        raise RuntimeError("Redemption category is not configured.")
+
+    category = guild.get_channel(REDEMPTION_TICKET_CATEGORY_ID)
+    if not isinstance(category, discord.CategoryChannel):
+        raise RuntimeError("Configured redemption category channel was not found.")
+
+    ch = await guild.create_text_channel(
+        f"ticket-{member.name}",
+        category=category,
+    )
+    await ch.set_permissions(guild.default_role, read_messages=False)
+    await ch.set_permissions(member, read_messages=True, send_messages=True)
+
+    for staff_role_id in (ADMIN_ROLE_ID, MODERATOR_ROLE_ID):
+        staff_role = guild.get_role(staff_role_id)
+        if staff_role:
+            await ch.set_permissions(
+                staff_role,
+                read_messages=True,
+                send_messages=True,
+                manage_messages=True,
+            )
+
+    await ch.edit(
+        topic=(
+            f"redemption-opener:{member.id}|item:{item}|budget_usd:{budget_cost:.2f}"
+        ),
+        reason="Store redemption ticket metadata",
+    )
+
+    instructions = _redemption_instructions(item)
+    item_price = _token_price_for_item(item)
+    balance_after = await get_user_balance(str(member.id))
+    balance_display_before = balance_after + item_price
+
+    ticket_embed = discord.Embed(
+        title=f"🎫 **{item.title()} Redemption Ticket**",
+        description=f"{member.mention}, please provide the following details in this ticket channel:\n\n{instructions}",
+        color=discord.Color.blue(),
+    )
+    ticket_embed.add_field(
+        name="Item Price", value=f"{item_price:,} R7 tokens", inline=True
+    )
+    ticket_embed.add_field(
+        name="Balance Before",
+        value=f"{int(round(balance_display_before)):,} R7 tokens",
+        inline=True,
+    )
+    ticket_embed.add_field(
+        name="Balance After",
+        value=f"{int(round(balance_after)):,} R7 tokens",
+        inline=True,
+    )
+    await ch.send(content=member.mention, embed=ticket_embed)
+    return ch
 
 
 async def close_redemption_ticket_channel(
@@ -478,6 +626,76 @@ class RedemptionClosedOptionsView(discord.ui.View):
         )
 
 
+class RedemptionQueueConfirmView(discord.ui.View):
+    """Asks the user whether to queue an over-budget redemption for next month."""
+
+    def __init__(self, user_id: str, item: str, budget_cost: float):
+        super().__init__(timeout=120)
+        self.user_id = user_id
+        self.item = item
+        self.budget_cost = budget_cost
+
+    @discord.ui.button(
+        label="Join queue for next month", style=discord.ButtonStyle.success
+    )
+    async def confirm_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        if str(interaction.user.id) != self.user_id:
+            await interaction.response.send_message(
+                "This prompt is not for you.", ephemeral=True
+            )
+            return
+
+        # Re-check ownership so a double /redeem can't queue the same item twice.
+        if await get_item_count(self.user_id, self.item) < 1:
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title="❌ **Queue Failed**",
+                    description="You no longer own this item.",
+                    color=discord.Color.red(),
+                ),
+                view=None,
+            )
+            return
+
+        await remove_item_token(self.user_id, self.item)
+        await add_redemption_queue_entry(self.user_id, self.item, self.budget_cost)
+        position = len(await get_redemption_queue())
+
+        item_display = SHOP_DATA.get(self.item, {}).get("display", self.item)
+        embed = discord.Embed(
+            title="📥 **Queued for Next Month**",
+            description=(
+                f"Your **{item_display}** redemption is queued at position "
+                f"**#{position}**.\nA ticket will open automatically once the "
+                "budget resets and can cover it. Use `/redemption-queue` to "
+                "check your status."
+            ),
+            color=discord.Color.green(),
+        )
+        await interaction.response.edit_message(embed=embed, view=None)
+        self.stop()
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        if str(interaction.user.id) != self.user_id:
+            await interaction.response.send_message(
+                "This prompt is not for you.", ephemeral=True
+            )
+            return
+
+        embed = discord.Embed(
+            title="🚫 **Redemption Cancelled**",
+            description="You keep your item — nothing was queued.",
+            color=discord.Color.greyple(),
+        )
+        await interaction.response.edit_message(embed=embed, view=None)
+        self.stop()
+
+
 # Helper
 async def shop_item_autocomplete(
     interaction: discord.Interaction, current: str
@@ -734,12 +952,81 @@ class Economy(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.supply_drop_task.start()
+        self.redemption_queue_task.start()
 
     async def cog_load(self):
         self.bot.add_view(RedemptionClosedOptionsView())
 
     def cog_unload(self):
         self.supply_drop_task.cancel()
+        self.redemption_queue_task.cancel()
+
+    # --- REDEMPTION QUEUE PROCESSING ---
+    @tasks.loop(hours=1)
+    async def redemption_queue_task(self):
+        await self.bot.wait_until_ready()
+
+        current_key = _budget_month_key()
+        processed_key = await get_setting("redemption_queue_processed_month")
+        if processed_key == current_key:
+            return
+
+        try:
+            await self.process_redemption_queue()
+        except Exception as e:
+            # Leave the month unstamped so the next hourly tick retries.
+            print(f"❌ Redemption queue processing failed: {e}")
+            return
+
+        await set_setting("redemption_queue_processed_month", current_key)
+
+    async def process_redemption_queue(self):
+        """Fulfills queued redemptions FIFO against the new month's budget.
+
+        Entries that don't fit the available budget stay queued and carry
+        over to the next month.
+        """
+        category = self.bot.get_channel(REDEMPTION_TICKET_CATEGORY_ID)
+        if not isinstance(category, discord.CategoryChannel):
+            raise RuntimeError("Redemption category channel was not found.")
+        guild = category.guild
+
+        for entry in await get_redemption_queue():
+            item = entry["item"]
+            user_id = entry["user_id"]
+            cost = _budget_cost_for_item(item)
+
+            member = guild.get_member(int(user_id))
+            if member is None:
+                # Opener left the server — drop the entry and refund tokens.
+                await remove_redemption_queue_entry(str(entry["_id"]))
+                refund = _token_price_for_item(item)
+                if refund > 0:
+                    await increment_user_balance(user_id, refund)
+                transcript_channel = self.bot.get_channel(
+                    REDEMPTION_TRANSCRIPT_CHANNEL_ID
+                )
+                if transcript_channel:
+                    await transcript_channel.send(
+                        f"📤 Queued **{item}** redemption for <@{user_id}> dropped "
+                        f"(user left the server) — {refund:,} R7 tokens refunded."
+                    )
+                continue
+
+            # Recompute each iteration: tickets created earlier in this run
+            # count as pending and reduce what's available.
+            _, _, _, available = await get_effective_budget(guild)
+            if cost > available:
+                continue
+
+            try:
+                await create_redemption_ticket(guild, member, item, cost)
+                await _increment_redeem_counter(item)
+            except Exception as e:
+                print(f"❌ Failed to open queued redemption for {user_id}: {e}")
+                continue
+
+            await remove_redemption_queue_entry(str(entry["_id"]))
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -983,130 +1270,64 @@ class Economy(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
-        # Budget guard: block redemption when monthly budget cannot cover this item.
+        # Budget guard: block redemption when the effective budget (monthly
+        # budget minus spent and pending tickets) cannot cover this item.
         budget_cost = _budget_cost_for_item(item)
         if budget_cost > 0:
-            _, _, remaining_budget = await get_budget_totals()
-            if budget_cost > remaining_budget:
+            _, spent, pending_usd, available = await get_effective_budget(
+                interaction.guild
+            )
+            if budget_cost > available:
                 embed = discord.Embed(
-                    title="❌ **Budget Limit Reached**",
+                    title="⏳ **Budget Limit Reached**",
                     description=(
                         f"This redemption requires **${budget_cost:.2f}**, but only "
-                        f"**${remaining_budget:.2f}** remains in the monthly budget."
+                        f"**${max(available, 0.0):.2f}** is available in the monthly "
+                        f"budget (${spent:.2f} spent, ${pending_usd:.2f} reserved by "
+                        "open tickets).\n\n"
+                        "You can join the queue for next month instead: your "
+                        f"**{item_info['display']}** will be consumed now, and a "
+                        "ticket will open automatically once the budget resets and "
+                        "can cover it."
                     ),
-                    color=discord.Color.red(),
+                    color=discord.Color.orange(),
                 )
-                await interaction.response.send_message(embed=embed, ephemeral=True)
+                await interaction.response.send_message(
+                    embed=embed,
+                    view=RedemptionQueueConfirmView(user_id, item, budget_cost),
+                    ephemeral=True,
+                )
                 return
 
         await interaction.response.defer()
 
         try:
-            if (
-                not isinstance(REDEMPTION_TICKET_CATEGORY_ID, int)
-                or REDEMPTION_TICKET_CATEGORY_ID <= 0
-            ):
-                await interaction.followup.send(
-                    "❌ Redemption category is not configured.",
-                    ephemeral=True,
-                )
-                return
-
-            category = interaction.guild.get_channel(REDEMPTION_TICKET_CATEGORY_ID)
-            if not isinstance(category, discord.CategoryChannel):
-                await interaction.followup.send(
-                    "❌ Configured redemption category channel was not found.",
-                    ephemeral=True,
-                )
-                return
-
-            balance_before = await get_user_balance(user_id)
+            # Re-check after defer in case a concurrent redemption claimed
+            # the remaining budget.
+            if budget_cost > 0:
+                _, _, _, available = await get_effective_budget(interaction.guild)
+                if budget_cost > available:
+                    await interaction.followup.send(
+                        "❌ The remaining budget was claimed by another redemption "
+                        "just now. Please run `/redeem` again.",
+                        ephemeral=True,
+                    )
+                    return
 
             await remove_item_token(user_id, item)
+            await _increment_redeem_counter(item)
 
-            tracking_keys = {
-                "brawl pass": "brawlpass_redeemed_count",
-                "brawl pass+": "brawlpass+_redeemed_count",
-                "nitro": "nitro_redeemed_count",
-                "paypal": "paypal_redeemed_count",
-                "shoutout": "shoutout_redeemed_count",
-            }
-            if item in tracking_keys:
-                key = tracking_keys[item]
-                current = int(await get_setting(key, "0"))
-                await set_setting(key, str(current + 1))
-
-            ch = await interaction.guild.create_text_channel(
-                f"ticket-{interaction.user.name}",
-                category=category,
-            )
-            await ch.set_permissions(
-                interaction.guild.default_role, read_messages=False
-            )
-            await ch.set_permissions(
-                interaction.user, read_messages=True, send_messages=True
+            ch = await create_redemption_ticket(
+                interaction.guild, interaction.user, item, budget_cost
             )
 
-            for staff_role_id in (ADMIN_ROLE_ID, MODERATOR_ROLE_ID):
-                staff_role = interaction.guild.get_role(staff_role_id)
-                if staff_role:
-                    await ch.set_permissions(
-                        staff_role,
-                        read_messages=True,
-                        send_messages=True,
-                        manage_messages=True,
-                    )
-
-            await ch.edit(
-                topic=(
-                    f"redemption-opener:{interaction.user.id}"
-                    f"|item:{item}|budget_usd:{budget_cost:.2f}"
-                ),
-                reason="Store redemption ticket metadata",
-            )
-
-            instructions = "- Provide necessary details."
-            if "brawl pass" in item:
-                instructions = "- Provide your in-game ID and a link to add you."
-            elif "brawl pass" in item:
-                instructions = "- Provide your in-game ID and a link to add you."
-            elif "nitro" in item:
-                instructions = (
-                    "- Provide the Discord account you'd like the Nitro gifted to."
-                )
-            elif "paypal" in item:
-                instructions = "- Provide your PayPal email address."
-            elif "shoutout" in item:
-                instructions = "- Provide the message you want to be shouted out."
-
+            instructions = _redemption_instructions(item)
             embed = discord.Embed(
                 title="✅ **Redemption Successful**",
                 description=f"A ticket has been created in {ch.mention}.\nPlease provide the following details to redeem your **{item_info['display']}**:\n{instructions}",
                 color=discord.Color.green(),
             )
             await interaction.followup.send(embed=embed)
-            item_price = item_info["price"]
-            balance_after = balance_before
-            balance_display_before = balance_before + item_price
-            ticket_embed = discord.Embed(
-                title=f"🎫 **{item.title()} Redemption Ticket**",
-                description=f"{interaction.user.mention}, please provide the following details in this ticket channel:\n\n{instructions}",
-                color=discord.Color.blue(),
-            )
-            ticket_embed.add_field(
-                name="Item Price", value=f"{item_price:,} R7 tokens", inline=True
-            )
-            ticket_embed.add_field(
-                name="Balance Before",
-                value=f"{int(round(balance_display_before)):,} R7 tokens",
-                inline=True,
-            )
-            ticket_embed.add_field(
-                name="Balance After",
-                value=f"{int(round(balance_after)):,} R7 tokens",
-                inline=True,
-            )
-            await ch.send(content=interaction.user.mention, embed=ticket_embed)
 
         except Exception as e:
             await add_item_token(user_id, item, quantity=1)
@@ -1278,11 +1499,12 @@ class Economy(commands.Cog):
         name="check-budget", description="Check the remaining budget for redemptions."
     )
     async def check_budget(self, interaction: discord.Interaction):
-        total_budget, total_spent, remaining = await get_budget_totals()
-
-        int(await get_setting("brawlpass_redeemed_count", "0"))
-        int(await get_setting("nitro_redeemed_count", "0"))
-        int(await get_setting("pin_redeemed_count", "0"))
+        total_budget, total_spent, pending_usd, available = await get_effective_budget(
+            interaction.guild
+        )
+        _, pending_count = _pending_redemptions_total(interaction.guild)
+        queue = await get_redemption_queue()
+        queued_usd = sum(_budget_cost_for_item(entry["item"]) for entry in queue)
 
         now = datetime.now(timezone.utc)
         if now.month == 12:
@@ -1295,8 +1517,107 @@ class Economy(commands.Cog):
         embed.description = (
             f"**Total Monthly Budget:** ${total_budget:.2f}\n"
             f"**Total Spent on Redemptions:** ${total_spent:.2f}\n"
-            f"**Remaining Budget:** ${remaining:.2f}\n"
+            f"**Pending Tickets:** ${pending_usd:.2f} ({pending_count} open)\n"
+            f"**Available Budget:** ${available:.2f}\n"
+            f"**Queued for Next Month:** {len(queue)} "
+            f"redemption(s) (${queued_usd:.2f} est.)\n"
             f"**Budget Resets:** <t:{reset_timestamp}:R> (<t:{reset_timestamp}:F>)"
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @app_commands.command(
+        name="redemption-queue",
+        description="See your queued redemptions for next month.",
+    )
+    async def redemption_queue_status(self, interaction: discord.Interaction):
+        user_id = str(interaction.user.id)
+        queue = await get_redemption_queue()
+        lines = []
+        for position, entry in enumerate(queue, start=1):
+            if entry["user_id"] != user_id:
+                continue
+            item_display = SHOP_DATA.get(entry["item"], {}).get(
+                "display", entry["item"]
+            )
+            cost = _budget_cost_for_item(entry["item"])
+            queued_ts = int(entry["queued_at"].replace(tzinfo=timezone.utc).timestamp())
+            lines.append(
+                f"**#{position}** — {item_display} (${cost:.2f}) — "
+                f"queued <t:{queued_ts}:R>"
+            )
+
+        embed = discord.Embed(
+            title="📥 **Your Redemption Queue**",
+            description="\n".join(lines)
+            if lines
+            else "You have nothing queued. Over-budget redemptions can be "
+            "queued from `/redeem`.",
+            color=discord.Color.blue(),
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @app_commands.command(
+        name="redemption-queue-list",
+        description="STAFF: List all queued redemptions.",
+    )
+    async def redemption_queue_list(self, interaction: discord.Interaction):
+        if not _is_redemption_staff(interaction.user):
+            await interaction.response.send_message(
+                "❌ Permission Denied", ephemeral=True
+            )
+            return
+
+        queue = await get_redemption_queue()
+        lines = []
+        total_usd = 0.0
+        for position, entry in enumerate(queue, start=1):
+            cost = _budget_cost_for_item(entry["item"])
+            total_usd += cost
+            queued_ts = int(entry["queued_at"].replace(tzinfo=timezone.utc).timestamp())
+            lines.append(
+                f"**{position}.** <@{entry['user_id']}> — {entry['item']} "
+                f"(${cost:.2f}) — queued <t:{queued_ts}:R> — id: `{entry['_id']}`"
+            )
+
+        embed = discord.Embed(
+            title="📥 **Redemption Queue**",
+            description="\n".join(lines) if lines else "The queue is empty.",
+            color=discord.Color.blue(),
+        )
+        embed.set_footer(
+            text=f"{len(queue)} entries | ${total_usd:.2f} estimated total"
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @app_commands.command(
+        name="redemption-queue-remove",
+        description="STAFF: Remove a queue entry and give the item back.",
+    )
+    @app_commands.describe(entry_id="The entry id shown in /redemption-queue-list")
+    async def redemption_queue_remove(
+        self, interaction: discord.Interaction, entry_id: str
+    ):
+        if not _is_redemption_staff(interaction.user):
+            await interaction.response.send_message(
+                "❌ Permission Denied", ephemeral=True
+            )
+            return
+
+        doc = await remove_redemption_queue_entry(entry_id)
+        if doc is None:
+            await interaction.response.send_message(
+                "❌ Queue entry not found.", ephemeral=True
+            )
+            return
+
+        await add_item_token(doc["user_id"], doc["item"])
+        embed = discord.Embed(
+            title="✅ **Queue Entry Removed**",
+            description=(
+                f"Removed the **{doc['item']}** redemption queued by "
+                f"<@{doc['user_id']}> — their item was returned to their inventory."
+            ),
+            color=discord.Color.green(),
         )
         await interaction.response.send_message(embed=embed, ephemeral=True)
 

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -1,12 +1,23 @@
 """Tests for pure functions in features/economy.py."""
 
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
 
+import discord
+import pytest
+
+from features.config import (
+    REDEMPTION_TICKET_CATEGORY_ID,
+    REDEMPTION_TRANSCRIPT_CHANNEL_ID,
+)
 from features.economy import (
+    Economy,
     _budget_month_key,
     _budget_cost_for_item,
-    _token_price_for_item,
     _extract_topic_value,
+    _pending_redemptions_total,
+    _redemption_instructions,
+    _token_price_for_item,
 )
 
 
@@ -94,3 +105,229 @@ def test_extract_topic_value_empty_topic():
 def test_extract_topic_value_empty_value():
     # key is present but value is empty string
     assert _extract_topic_value("key:", "key") == ""
+
+
+# --- _redemption_instructions ---
+
+
+def test_instructions_brawl_pass():
+    assert "in-game ID" in _redemption_instructions("brawl pass")
+    assert "in-game ID" in _redemption_instructions("brawl pass+")
+
+
+def test_instructions_nitro():
+    assert "Nitro" in _redemption_instructions("nitro")
+
+
+def test_instructions_paypal():
+    assert "PayPal" in _redemption_instructions("paypal")
+
+
+def test_instructions_shoutout():
+    assert "shouted out" in _redemption_instructions("shoutout")
+
+
+def test_instructions_default():
+    assert _redemption_instructions("pin") == "- Provide necessary details."
+
+
+# --- _pending_redemptions_total ---
+
+
+def _fake_ticket_channel(topic):
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.topic = topic
+    return channel
+
+
+def _fake_guild_with_tickets(topics):
+    category = MagicMock(spec=discord.CategoryChannel)
+    category.text_channels = [_fake_ticket_channel(t) for t in topics]
+    guild = MagicMock(spec=discord.Guild)
+    guild.get_channel = MagicMock(
+        side_effect=lambda cid: (
+            category if cid == REDEMPTION_TICKET_CATEGORY_ID else None
+        )
+    )
+    return guild
+
+
+def test_pending_total_none_guild():
+    assert _pending_redemptions_total(None) == (0.0, 0)
+
+
+def test_pending_total_category_not_found():
+    guild = MagicMock(spec=discord.Guild)
+    guild.get_channel = MagicMock(return_value=None)
+    assert _pending_redemptions_total(guild) == (0.0, 0)
+
+
+def test_pending_total_empty_category():
+    guild = _fake_guild_with_tickets([])
+    assert _pending_redemptions_total(guild) == (0.0, 0)
+
+
+def test_pending_total_sums_ticket_topics():
+    guild = _fake_guild_with_tickets(
+        [
+            "redemption-opener:1|item:brawl pass|budget_usd:10.00",
+            "redemption-opener:2|item:paypal|budget_usd:15.00",
+        ]
+    )
+    assert _pending_redemptions_total(guild) == (25.0, 2)
+
+
+def test_pending_total_skips_non_ticket_channels():
+    guild = _fake_guild_with_tickets(
+        [
+            None,
+            "just a normal channel topic",
+            "redemption-opener:1|item:nitro|budget_usd:10.00",
+        ]
+    )
+    assert _pending_redemptions_total(guild) == (10.0, 1)
+
+
+def test_pending_total_falls_back_to_item_cost():
+    guild = _fake_guild_with_tickets(
+        [
+            "redemption-opener:1|item:brawl pass",  # missing budget_usd
+            "redemption-opener:2|item:paypal|budget_usd:notanumber",
+        ]
+    )
+    assert _pending_redemptions_total(guild) == (25.0, 2)
+
+
+def test_pending_total_ignores_zero_cost_tickets():
+    guild = _fake_guild_with_tickets(
+        [
+            "redemption-opener:1|item:shoutout|budget_usd:0.00",
+            "redemption-opener:2|item:nitro|budget_usd:10.00",
+        ]
+    )
+    assert _pending_redemptions_total(guild) == (10.0, 1)
+
+
+# --- process_redemption_queue ---
+
+
+def _make_economy_cog(category):
+    cog = Economy.__new__(Economy)  # skip __init__ so task loops don't start
+    bot = MagicMock()
+    transcript_channel = MagicMock()
+    transcript_channel.send = AsyncMock()
+    channels = {
+        REDEMPTION_TICKET_CATEGORY_ID: category,
+        REDEMPTION_TRANSCRIPT_CHANNEL_ID: transcript_channel,
+    }
+    bot.get_channel = MagicMock(side_effect=channels.get)
+    cog.bot = bot
+    return cog, transcript_channel
+
+
+def _make_category_with_members(member_ids):
+    category = MagicMock(spec=discord.CategoryChannel)
+    guild = MagicMock(spec=discord.Guild)
+    members = {mid: MagicMock(spec=discord.Member) for mid in member_ids}
+    guild.get_member = MagicMock(side_effect=members.get)
+    category.guild = guild
+    return category
+
+
+def _patch_queue_helpers(monkeypatch, entries, budgets):
+    """Patches the queue processing collaborators; returns the key mocks."""
+    create_ticket = AsyncMock()
+    remove_entry = AsyncMock()
+    refund = AsyncMock()
+    monkeypatch.setattr(
+        "features.economy.get_redemption_queue", AsyncMock(return_value=entries)
+    )
+    monkeypatch.setattr(
+        "features.economy.get_effective_budget",
+        AsyncMock(side_effect=[(50.0, 0.0, 0.0, b) for b in budgets]),
+    )
+    monkeypatch.setattr("features.economy.create_redemption_ticket", create_ticket)
+    monkeypatch.setattr("features.economy.remove_redemption_queue_entry", remove_entry)
+    monkeypatch.setattr("features.economy.increment_user_balance", refund)
+    monkeypatch.setattr("features.economy._increment_redeem_counter", AsyncMock())
+    return create_ticket, remove_entry, refund
+
+
+async def test_queue_processing_fulfills_fifo(monkeypatch):
+    category = _make_category_with_members([1, 2])
+    cog, _ = _make_economy_cog(category)
+    entries = [
+        {"_id": "a1", "user_id": "1", "item": "brawl pass"},
+        {"_id": "a2", "user_id": "2", "item": "paypal"},
+    ]
+    create_ticket, remove_entry, _ = _patch_queue_helpers(
+        monkeypatch, entries, budgets=[50.0, 40.0]
+    )
+
+    await cog.process_redemption_queue()
+
+    assert create_ticket.await_count == 2
+    first_item = create_ticket.await_args_list[0].args[2]
+    second_item = create_ticket.await_args_list[1].args[2]
+    assert (first_item, second_item) == ("brawl pass", "paypal")
+    assert remove_entry.await_count == 2
+
+
+async def test_queue_processing_skips_unaffordable_entry(monkeypatch):
+    category = _make_category_with_members([1, 2])
+    cog, _ = _make_economy_cog(category)
+    entries = [
+        {"_id": "a1", "user_id": "1", "item": "paypal"},  # $15 > $12 available
+        {"_id": "a2", "user_id": "2", "item": "brawl pass"},  # $10 fits
+    ]
+    create_ticket, remove_entry, _ = _patch_queue_helpers(
+        monkeypatch, entries, budgets=[12.0, 12.0]
+    )
+
+    await cog.process_redemption_queue()
+
+    assert create_ticket.await_count == 1
+    assert create_ticket.await_args.args[2] == "brawl pass"
+    remove_entry.assert_awaited_once_with("a2")
+
+
+async def test_queue_processing_refunds_when_member_left(monkeypatch):
+    category = _make_category_with_members([])
+    cog, transcript_channel = _make_economy_cog(category)
+    entries = [{"_id": "a1", "user_id": "1", "item": "brawl pass"}]
+    create_ticket, remove_entry, refund = _patch_queue_helpers(
+        monkeypatch, entries, budgets=[50.0]
+    )
+
+    await cog.process_redemption_queue()
+
+    create_ticket.assert_not_awaited()
+    remove_entry.assert_awaited_once_with("a1")
+    refund.assert_awaited_once_with("1", _token_price_for_item("brawl pass"))
+    transcript_channel.send.assert_awaited_once()
+
+
+async def test_queue_entry_kept_when_ticket_creation_fails(monkeypatch):
+    category = _make_category_with_members([1, 2])
+    cog, _ = _make_economy_cog(category)
+    entries = [
+        {"_id": "a1", "user_id": "1", "item": "brawl pass"},
+        {"_id": "a2", "user_id": "2", "item": "nitro"},
+    ]
+    create_ticket, remove_entry, _ = _patch_queue_helpers(
+        monkeypatch, entries, budgets=[50.0, 40.0]
+    )
+    create_ticket.side_effect = [Exception("boom"), MagicMock()]
+
+    await cog.process_redemption_queue()
+
+    assert create_ticket.await_count == 2
+    remove_entry.assert_awaited_once_with("a2")
+
+
+async def test_queue_processing_raises_without_category(monkeypatch):
+    cog, _ = _make_economy_cog(None)
+    _patch_queue_helpers(monkeypatch, [], budgets=[])
+
+    with pytest.raises(RuntimeError):
+        await cog.process_redemption_queue()


### PR DESCRIPTION
### Changes
  - Fixed the `/redeem` budget check to subtract open (pending) redemption tickets, so tickets can no longer collectively exceed
  the monthly cap
  - Added a FIFO redemption queue: over-budget requests can opt in, and an hourly task fulfills them automatically when the
  budget resets (unaffordable entries carry over; leavers get refunded)
  - Updated `/check-budget` with pending/queue totals and added `/redemption-queue`, `/redemption-queue-list`,
  `/redemption-queue-remove`
  - Updated `docs/ECONOMY_SHOP.md` and added unit tests

Closes #338