### PR TITLE
337-Feature add optional image upload to tourney ticket modals

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -33,7 +33,7 @@ pytest-asyncio>=0.23
 
 | Package | Used by |
 |---------|---------|
-| `discord.py>=2.7` | Everything — requires 2.x for app commands and modals |
+| `discord.py>=2.7` | Everything — 2.7 specifically is required for the `discord.ui.FileUpload` / `discord.ui.Label` modal components used by tourney ticket image upload |
 | `motor` | All MongoDB operations (async driver) |
 | `dnspython` + `certifi` | Required by motor for MongoDB Atlas SRV connection strings |
 | `python-dotenv` | Loading `.env` file |

--- a/docs/TOURNEY_TICKETS.md
+++ b/docs/TOURNEY_TICKETS.md
@@ -8,10 +8,11 @@ Tournament tickets are private Discord text channels created when a member submi
 ## Ticket Creation Flow
 
 1. Member clicks the **Open Ticket** button on the tourney panel
-2. A Discord modal appears with three fields:
+2. A Discord modal appears with three text fields plus an optional file upload:
    - Team Name
    - Match / Bracket Number
    - Issue description
+   - Screenshots (optional, up to 3 images via Discord's native modal file upload)
 3. On submit, `create_tourney_ticket_channel()` runs:
    - Defers the response (ephemeral) immediately to buy time
    - Checks that the active category has **< 50 channels** (Discord's hard limit)
@@ -21,7 +22,9 @@ Tournament tickets are private Discord text channels created when a member submi
    - Sets permission overwrites: opener gets full access + slash commands; all `ALLOWED_STAFF_ROLES` get full access + manage messages; `@everyone` is hidden
    - Writes the channel topic: `tourney-opener:{user_id}|team:{team}|bracket:{num}|issue:{issue}`
    - Auto-detects and translates the issue text if non-English
-   - Sends the ticket embed + a "proof required" embed
+   - Sends the ticket embed
+   - Re-uploads any modal-submitted images into the channel via `_post_submitted_images()`, **one message per image** so each renders full-size, prefixed with `🖼️ **Submitted Images** from **Name** (1/3):` (`SUBMITTED_IMAGES_MARKER`; display name is markdown-escaped, counter omitted for a single image, no ping) — interaction attachments are not guaranteed to persist on Discord's CDN, so re-posting makes them durable and lets the delete flow find them again. Non-image files are filtered out (`_filter_image_attachments()`) and a "⚠️ N submitted file(s) were ignored" notice is posted so the opener knows; if a re-upload fails (e.g. size limit), that image falls back to a CDN link
+   - Sends the "proof required" embed (pings the opener); when the opener attached screenshots in the modal, it includes a "✅ Screenshots Received" field saying no further proof is needed
    - Checks the opener against the blacklist and alerts admins if flagged
 
 ### Channel Naming Convention
@@ -125,9 +128,10 @@ This is non-blocking — the ticket opens regardless.
 3. Calls `_unregister_ticket_for_user()` to release the slot
 4. Builds a plain-text transcript via `build_transcript_text()`
 5. Creates two `io.BytesIO` copies of the transcript (one for DM, one for log channel) — must be separate because `discord.File` is single-use
-6. DMs the transcript to the opener (if findable via `client.get_user()` or `client.fetch_user()`)
-7. Posts the transcript to `LOG_CHANNEL_ID` with metadata extracted from the topic (team name, match number)
-8. Calls `channel.delete()`
+6. Re-downloads any images from the `🖼️ Submitted Images` marker messages via `_collect_submitted_images()` (scans the first 25 messages; capped at 9 images so transcript + images stay within Discord's 10-attachments-per-message limit). Images are downloaded once as raw bytes and fresh `discord.File` objects are built per destination, since `discord.File` is single-use
+7. DMs the transcript to the opener (if findable via `client.get_user()` or `client.fetch_user()`) with the submitted images attached — if the images push the DM over a limit, retries with the transcript alone
+8. Posts the transcript to `LOG_CHANNEL_ID` with metadata extracted from the topic (team name, match number) and the submitted images attached — same retry-without-images fallback
+9. Calls `channel.delete()`
 
 ### Transcript Format
 

--- a/docs/TOURNEY_VIEWS.md
+++ b/docs/TOURNEY_VIEWS.md
@@ -28,6 +28,9 @@ The modal that appears when a member clicks "Open Tourney Ticket" during a live 
 | `team_name` | Matcherino Team Name | Yes | 100 | Used for fuzzy matching |
 | `bracket` | Match No. | Yes | 50 | Parsed as `int`; if non-integer, falls back to team name lookup |
 | `issue` | Issue / Report | Yes | 1000 | Paragraph style (`discord.TextStyle.paragraph`) |
+| `image_upload` | Screenshots (Optional) | No | 3 files | `discord.ui.FileUpload` (requires discord.py ≥ 2.7); values passed to `create_tourney_ticket_channel(images=…)` |
+
+**Component structure note**: Every field (text inputs included) is wrapped in a `discord.ui.Label` rather than added directly. Discord rejects modals that mix legacy ActionRow text inputs with new components like `FileUpload` — so once one new-style component is present, all fields must use Labels. Field titles live on the `Label`, not on the `TextInput`.
 
 **`on_submit` logic** (the most complex part of the views file):
 
@@ -76,6 +79,7 @@ The modal for pre-tournament support tickets. Simpler than `TourneyReportModal` 
 |-------|-------|----------|-----------|
 | `team_name` | Team Name (Optional) | No | 100 |
 | `issue` | Issue / Question | Yes | 1000 |
+| `image_upload` | Screenshots (Optional) | No | 3 files |
 
 **`on_submit`**: Calls `create_pre_tourney_ticket_channel()` directly. No Matcherino lookup is performed (no bracket data exists pre-tournament). Also increments the tourney queue counter.
 

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -1465,7 +1465,8 @@ def setup_tourney_commands(bot: commands.Bot):
                 "You’ll be prompted to provide:\n"
                 "📛 **Team Name**\n"
                 "🔢 **Match / Bracket Number**\n"
-                "📝 **Description of the Issue**\n\n"
+                "📝 **Description of the Issue**\n"
+                "🖼️ **Screenshots** *(optional, up to 3)*\n\n"
                 "A Tourney Admin will assist you as soon as possible. 🛠️"
             )
 
@@ -1965,7 +1966,8 @@ def setup_tourney_commands(bot: commands.Bot):
                     "📋 **Registration Issues**\n"
                     "🤝 **Team / Roster Questions**\n"
                     "❓ **General Inquiries**\n\n"
-                    "Click the button below to open a ticket. **Team Name** is optional."
+                    "Click the button below to open a ticket. **Team Name** is optional, "
+                    "and you can attach up to 3 screenshots."
                 ),
                 color=discord.Color.orange(),
             )
@@ -2043,7 +2045,8 @@ def setup_tourney_commands(bot: commands.Bot):
             "You’ll be prompted to provide:\n"
             "📛 **Team Name**\n"
             "🔢 **Match / Bracket Number**\n"
-            "📝 **Description of the Issue**\n\n"
+            "📝 **Description of the Issue**\n"
+            "🖼️ **Screenshots** *(optional, up to 3)*\n\n"
             "A Tourney Admin will assist you as soon as possible. 🛠️"
         )
 
@@ -2083,7 +2086,8 @@ def setup_tourney_commands(bot: commands.Bot):
                 "📋 **Registration Issues**\n"
                 "🤝 **Team / Roster Questions**\n"
                 "❓ **General Inquiries**\n\n"
-                "Click the button below to open a ticket. **Team Name** is optional."
+                "Click the button below to open a ticket. **Team Name** is optional, "
+                "and you can attach up to 3 screenshots."
             ),
             color=discord.Color.orange(),
         )

--- a/features/tourney/tourney_utils.py
+++ b/features/tourney/tourney_utils.py
@@ -22,6 +22,10 @@ from features.config import (
 _ticket_counter: int = 1
 _pre_tourney_ticket_counter: int = 1
 
+# Prefix of the bot message that carries images submitted via the ticket modal.
+# Used to find those images again when the transcript is generated on delete.
+SUBMITTED_IMAGES_MARKER = "🖼️ **Submitted Images**"
+
 # user_id -> set of open ticket channel IDs
 _user_open_tickets: dict[int, set[int]] = {}
 
@@ -43,6 +47,72 @@ async def _get_translation(text: str) -> str | None:
         return translated
     except Exception:
         return None
+
+
+def _filter_image_attachments(
+    attachments: list[discord.Attachment] | None,
+) -> list[discord.Attachment]:
+    """Keep only attachments Discord identifies as images."""
+    if not attachments:
+        return []
+    return [
+        a for a in attachments if a.content_type and a.content_type.startswith("image/")
+    ]
+
+
+async def _post_submitted_images(
+    channel: discord.TextChannel,
+    opener: discord.abc.User,
+    attachments: list[discord.Attachment] | None,
+) -> None:
+    """Re-upload modal-submitted images into the ticket channel.
+
+    Interaction attachments are not guaranteed to stay on Discord's CDN, so the
+    images are re-sent as bot-owned files. The marker content lets
+    delete_ticket_with_transcript() find them again for the transcript log.
+    """
+    if not attachments:
+        return
+
+    images = _filter_image_attachments(attachments)
+
+    # Tell the user when uploads were discarded, otherwise they believe their
+    # proof was submitted while staff sees nothing.
+    dropped = len(attachments) - len(images)
+    if dropped:
+        plural = "s were" if dropped > 1 else " was"
+        try:
+            await channel.send(
+                f"⚠️ {dropped} submitted file{plural} ignored — only images "
+                f"(PNG, JPG, etc.) are accepted. Please post other proof "
+                f"directly in this channel."
+            )
+        except Exception:
+            pass
+
+    if not images:
+        return
+
+    # One message per image so each renders full-size instead of as a collage.
+    # No mention here — the opener is already pinged by the proof embed message,
+    # and a second ping on ticket open is noisy.
+    total = len(images)
+    opener_name = discord.utils.escape_markdown(opener.display_name)
+    for index, attachment in enumerate(images, start=1):
+        counter = f" ({index}/{total})" if total > 1 else ""
+        content = f"{SUBMITTED_IMAGES_MARKER} from **{opener_name}**{counter}:"
+        try:
+            file = await attachment.to_file()
+            await channel.send(content=content, file=file)
+        except discord.HTTPException:
+            # Upload failed (e.g. over the guild size limit) — fall back to a link
+            # so staff can at least view the image while the interaction lives.
+            try:
+                await channel.send(content=f"{content}\n{attachment.url}")
+            except Exception:
+                pass
+        except Exception:
+            continue
 
 
 def _get_open_ticket_count(user_id: int) -> int:
@@ -133,6 +203,7 @@ async def create_tourney_ticket_channel(
     team_name: str,
     bracket: str,
     issue: str,
+    images: list[discord.Attachment] | None = None,
 ):
     await interaction.response.defer(ephemeral=True)
     guild = interaction.guild
@@ -232,6 +303,8 @@ async def create_tourney_ticket_channel(
 
     await channel.send(embed=ticket_embed)
 
+    await _post_submitted_images(channel, interaction.user, images)
+
     proof_embed = discord.Embed(
         title="📎 Proof Required",
         description=(
@@ -244,6 +317,16 @@ async def create_tourney_ticket_channel(
         ),
         color=discord.Color.red(),
     )
+
+    if _filter_image_attachments(images):
+        proof_embed.add_field(
+            name="✅ Screenshots Received",
+            value=(
+                "The screenshot(s) you attached when opening this ticket count "
+                "as proof — nothing more is needed unless a Tourney Admin asks."
+            ),
+            inline=False,
+        )
 
     await channel.send(
         content=f"{interaction.user.mention} 👇 **Please read this:**",
@@ -271,6 +354,7 @@ async def create_pre_tourney_ticket_channel(
     interaction: discord.Interaction,
     team_name: str | None,
     issue: str,
+    images: list[discord.Attachment] | None = None,
 ):
     await interaction.response.defer(ephemeral=True)
 
@@ -366,6 +450,9 @@ async def create_pre_tourney_ticket_channel(
         )
 
     await channel.send(embed=ticket_embed)
+
+    await _post_submitted_images(channel, interaction.user, images)
+
     await interaction.followup.send(
         f"Support ticket created: {channel.mention}", ephemeral=True
     )
@@ -575,6 +662,44 @@ async def build_transcript_text(channel: discord.TextChannel) -> str:
     return "\n".join(lines)
 
 
+async def _collect_submitted_images(
+    channel: discord.TextChannel,
+    client: discord.Client,
+) -> list[tuple[bytes, str]]:
+    """Re-download the images posted by _post_submitted_images() as
+    (bytes, filename) pairs before the channel (and its CDN links) is deleted.
+
+    Raw bytes rather than discord.File so the caller can send the same images
+    to multiple destinations (opener DM + log channel) with a single download —
+    discord.File objects are single-use. The marker messages are among the
+    first in the channel."""
+    bot_id = client.user.id if client.user else None
+    if bot_id is None:
+        return []
+
+    images: list[tuple[bytes, str]] = []
+    try:
+        # Each submitted image is its own marker message, so keep scanning
+        # instead of stopping at the first hit.
+        async for msg in channel.history(limit=25, oldest_first=True):
+            if msg.author.id != bot_id or not msg.content.startswith(
+                SUBMITTED_IMAGES_MARKER
+            ):
+                continue
+            for attachment in msg.attachments:
+                # Cap at 9 so transcript file + images stay within the
+                # 10-attachments-per-message limit.
+                if len(images) >= 9:
+                    return images
+                try:
+                    images.append((await attachment.read(), attachment.filename))
+                except Exception:
+                    continue
+    except Exception:
+        pass
+    return images
+
+
 async def delete_ticket_with_transcript(
     guild: discord.Guild,
     channel: discord.TextChannel,
@@ -617,6 +742,17 @@ async def delete_ticket_with_transcript(
     file_for_dm = discord.File(bytes_for_dm, filename=filename)
     file_for_log = discord.File(bytes_for_log, filename=filename)
 
+    # Images submitted with the ticket modal, downloaded once and re-sent to
+    # both the opener DM and the log channel so they survive channel deletion.
+    submitted_images = await _collect_submitted_images(channel, client)
+
+    def _image_files() -> list[discord.File]:
+        # discord.File is single-use, so each send needs fresh objects.
+        return [
+            discord.File(io.BytesIO(data), filename=name)
+            for data, name in submitted_images
+        ]
+
     # DM opener
     if opener_id is not None:
         user = client.get_user(opener_id)
@@ -627,16 +763,28 @@ async def delete_ticket_with_transcript(
                 user = None
 
         if user is not None:
+            dm_content = (
+                f"Here is the transcript for your closed ticket: "
+                f"**#{channel.name}** in **{guild.name}**."
+            )
             try:
                 await user.send(
-                    content=(
-                        f"Here is the transcript for your closed ticket: "
-                        f"**#{channel.name}** in **{guild.name}**."
-                    ),
-                    file=file_for_dm,
+                    content=dm_content,
+                    files=[file_for_dm, *_image_files()],
                 )
             except discord.Forbidden:
                 pass
+            except discord.HTTPException:
+                if not submitted_images:
+                    raise
+                # Images pushed the DM over a limit — retry transcript only.
+                retry_dm = discord.File(
+                    io.BytesIO(transcript_text.encode("utf-8")), filename=filename
+                )
+                try:
+                    await user.send(content=dm_content, files=[retry_dm])
+                except discord.Forbidden:
+                    pass
 
     # Log channel
     log_channel = guild.get_channel(LOG_CHANNEL_ID) if LOG_CHANNEL_ID else None
@@ -666,14 +814,26 @@ async def delete_ticket_with_transcript(
                 match_num = bracket_match.group(1).strip()
 
         # 👇 2. Update Content
-        await log_channel.send(
-            content=(
-                f"📝 Transcript for ticket **#{channel.name}** "
-                f"deleted by **{deleter_name}** (opener: {opener_mention}).\n"
-                f"🛡️ **Team:** `{team_name}` | 🔢 **Match:** `{match_num}`"
-            ),
-            file=file_for_log,
+        log_content = (
+            f"📝 Transcript for ticket **#{channel.name}** "
+            f"deleted by **{deleter_name}** (opener: {opener_mention}).\n"
+            f"🛡️ **Team:** `{team_name}` | 🔢 **Match:** `{match_num}`"
         )
+
+        try:
+            await log_channel.send(
+                content=log_content,
+                files=[file_for_log, *_image_files()],
+            )
+        except discord.HTTPException:
+            if not submitted_images:
+                raise
+            # Image upload pushed the message over a limit — send the
+            # transcript alone rather than losing it entirely.
+            retry_file = discord.File(
+                io.BytesIO(transcript_text.encode("utf-8")), filename=filename
+            )
+            await log_channel.send(content=log_content, files=[retry_file])
 
     await channel.delete(reason=f"Tourney ticket deleted by {deleter}")
 

--- a/features/tourney/tourney_views.py
+++ b/features/tourney/tourney_views.py
@@ -10,30 +10,44 @@ class TourneyReportModal(discord.ui.Modal, title="Tourney Support"):
     def __init__(self):
         super().__init__()
 
+        # All inputs are wrapped in Labels: Discord rejects modals that mix
+        # legacy ActionRow text inputs with new components like FileUpload.
         self.team_name = discord.ui.TextInput(
-            label="Matcherino Team Name",
             placeholder="Ex. XYZ",
             required=True,
             max_length=100,
         )
         self.bracket = discord.ui.TextInput(
-            label="Match No.",
             placeholder="Ex. 3, 23, 145",
             required=True,
             max_length=50,
         )
         self.issue = discord.ui.TextInput(
-            label="Issue / Report",
             placeholder="Describe the issue you are trying to report…",
             style=discord.TextStyle.paragraph,
             required=True,
             max_length=1000,
         )
+        self.image_upload = discord.ui.FileUpload(
+            custom_id="tourney_ticket_images",
+            required=False,
+            min_values=0,
+            max_values=3,
+        )
 
         # add the inputs to the modal
-        self.add_item(self.team_name)
-        self.add_item(self.bracket)
-        self.add_item(self.issue)
+        self.add_item(
+            discord.ui.Label(text="Matcherino Team Name", component=self.team_name)
+        )
+        self.add_item(discord.ui.Label(text="Match No.", component=self.bracket))
+        self.add_item(discord.ui.Label(text="Issue / Report", component=self.issue))
+        self.add_item(
+            discord.ui.Label(
+                text="Screenshots (Optional)",
+                description="Attach up to 3 images as proof for your report.",
+                component=self.image_upload,
+            )
+        )
 
     async def on_submit(self, interaction: discord.Interaction):
         from .tourney_utils import create_tourney_ticket_channel
@@ -44,6 +58,7 @@ class TourneyReportModal(discord.ui.Modal, title="Tourney Support"):
             team_name=self.team_name.value,
             bracket=self.bracket.value,
             issue=self.issue.value,
+            images=self.image_upload.values,
         )
 
         try:
@@ -498,22 +513,37 @@ class PreTourneyReportModal(discord.ui.Modal, title="Pre-Tourney Support"):
     def __init__(self):
         super().__init__()
 
+        # All inputs are wrapped in Labels: Discord rejects modals that mix
+        # legacy ActionRow text inputs with new components like FileUpload.
         self.team_name = discord.ui.TextInput(
-            label="Team Name (Optional)",
             placeholder="Ex. XYZ",
             required=False,  # <--- NOT REQUIRED
             max_length=100,
         )
         self.issue = discord.ui.TextInput(
-            label="Issue / Question",
             placeholder="How can we help?",
             style=discord.TextStyle.paragraph,
             required=True,  # <--- REQUIRED
             max_length=1000,
         )
+        self.image_upload = discord.ui.FileUpload(
+            custom_id="pretourney_ticket_images",
+            required=False,
+            min_values=0,
+            max_values=3,
+        )
 
-        self.add_item(self.team_name)
-        self.add_item(self.issue)
+        self.add_item(
+            discord.ui.Label(text="Team Name (Optional)", component=self.team_name)
+        )
+        self.add_item(discord.ui.Label(text="Issue / Question", component=self.issue))
+        self.add_item(
+            discord.ui.Label(
+                text="Screenshots (Optional)",
+                description="Attach up to 3 images related to your question.",
+                component=self.image_upload,
+            )
+        )
 
     async def on_submit(self, interaction: discord.Interaction):
         from .tourney_utils import create_pre_tourney_ticket_channel
@@ -522,6 +552,7 @@ class PreTourneyReportModal(discord.ui.Modal, title="Pre-Tourney Support"):
             interaction,
             team_name=self.team_name.value,
             issue=self.issue.value,
+            images=self.image_upload.values,
         )
 
         try:

--- a/tests/test_tourney_utils.py
+++ b/tests/test_tourney_utils.py
@@ -136,3 +136,37 @@ def test_unregister_nonexistent_channel_does_not_raise():
     tu._register_ticket_for_user(888, 8001)
     tu._unregister_ticket_for_user(888, 9999)  # channel not in set
     assert tu._get_open_ticket_count(888) == 1
+
+
+# --- _filter_image_attachments ---
+
+
+class _FakeAttachment:
+    def __init__(self, content_type):
+        self.content_type = content_type
+
+
+def test_filter_image_attachments_none_input():
+    assert tu._filter_image_attachments(None) == []
+
+
+def test_filter_image_attachments_empty_list():
+    assert tu._filter_image_attachments([]) == []
+
+
+def test_filter_image_attachments_keeps_images():
+    png = _FakeAttachment("image/png")
+    jpeg = _FakeAttachment("image/jpeg")
+    assert tu._filter_image_attachments([png, jpeg]) == [png, jpeg]
+
+
+def test_filter_image_attachments_drops_non_images():
+    png = _FakeAttachment("image/png")
+    video = _FakeAttachment("video/mp4")
+    text = _FakeAttachment("text/plain")
+    assert tu._filter_image_attachments([png, video, text]) == [png]
+
+
+def test_filter_image_attachments_drops_missing_content_type():
+    unknown = _FakeAttachment(None)
+    assert tu._filter_image_attachments([unknown]) == []


### PR DESCRIPTION
### Changes
- Added an optional "Screenshots" upload (up to 3 images) to the tourney and pre-tourney ticket modals using discord.py 2.7's native `FileUpload` component; all modal fields are `Label`-wrapped since Discord doesn't allow mixing legacy text inputs with new components
- Submitted images are re-posted into the ticket channel one message per image (non-image files are filtered out with a notice), and the "Proof Required" embed acknowledges screenshots already received
- On ticket deletion, submitted images are attached to the transcript message in both the log channel and the opener's DM, with fallbacks so the transcript is never lost if the images fail to send
- Panel embeds (`!starttourney`, `!endtourney`, `/tourney-panel`, `/pre-tourney-panel`) mention the optional screenshot upload
- Added unit tests for the image filter and updated the tourney docs + `SETUP.md`

### Notes
- Only modal-submitted images are preserved on ticket deletion; preserving proof images posted later in the ticket channel was considered and deferred.

<details>
<summary><h3>Screenshots</h3></summary>

New Screenshots field:     
<img width="373" height="572" alt="Tourney Support" src="https://github.com/user-attachments/assets/e3d55343-e11a-4536-a87e-218f883eaa4c" />

Ticket Creation:
<img width="483" height="690" alt="New Tournament Ticket" src="https://github.com/user-attachments/assets/849db77c-7d00-4239-82e0-194fdb8bce69" />

Transcript Message:
<img width="912" height="409" alt="transcret for toket a ena ticket-001 deleted by remainingfelta dopener ON" src="https://github.com/user-attachments/assets/bc616b45-3705-4a91-97fc-afffc3b7394d" />

</details>

Closes #337