### PR TITLE
347-Feature add monthly 10% booster shop discount with 14-day boost gate

### DIFF
--- a/database/mongo.py
+++ b/database/mongo.py
@@ -153,6 +153,20 @@ async def add_item_token(user_id: str, item_name: str, quantity: int = 1):
     )
 
 
+async def get_booster_discount_month(user_id: str) -> str | None:
+    """Returns the "YYYY-MM" month key of the user's last booster discount use."""
+    doc = await get_user_data(user_id)
+    return doc.get("booster_discount_month")
+
+
+async def set_booster_discount_month(user_id: str, month_key: str):
+    if db is None:
+        return
+    await db.users.update_one(
+        {"_id": user_id}, {"$set": {"booster_discount_month": month_key}}, upsert=True
+    )
+
+
 async def get_item_count(user_id: str, item_name: str) -> int:
     """Checks how many of an item a user has."""
     doc = await get_user_data(user_id)

--- a/docs/CONFIG_SYSTEM.md
+++ b/docs/CONFIG_SYSTEM.md
@@ -67,6 +67,7 @@ Key IDs defined in config:
 | `TRIAL_MODERATOR_ROLE_ID` | Trial mod (limited access) |
 | `TOURNEY_ADMIN_ROLE_ID` | Tournament staff (granted `moderate_members` during live tourney) |
 | `MEMBER_ROLE_ID` | Base member role |
+| `SERVER_BOOSTER_ROLE_ID` | Server Booster perks (token/XP bonuses, daily bonus, shop discount); dev reuses the prod ID since the dev server has no booster role |
 | `ALLOWED_STAFF_ROLES` | List of role IDs with tourney ticket access |
 
 ---

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -35,6 +35,7 @@ Key fields:
 | `exp` | int | Total XP |
 | `daily_last_claimed` | datetime | Last `/daily` claim timestamp |
 | `daily_message_count` | int | Messages since last `/daily` |
+| `booster_discount_month` | str | `"YYYY-MM"` of the last booster shop discount use |
 | `brawlers` | dict | Map of `brawler_id → {level, gadgets, star_powers, hypercharge, coins, power_points}` |
 | `coins` | int | Brawl coins |
 | `power_points` | int | Brawl power points |

--- a/docs/ECONOMY_SHOP.md
+++ b/docs/ECONOMY_SHOP.md
@@ -35,6 +35,22 @@ REDEMPTION_BUDGET_COSTS = {
 
 ---
 
+## Booster Discount
+
+Server Boosters get a **10% token discount on one shop purchase per calendar month**, applied automatically at `/buy` time. Eligibility (`_booster_discount_available()`):
+
+1. Has the Server Booster role (`SERVER_BOOSTER_ROLE_ID`)
+2. `member.premium_since` is at least **14 days** ago — `premium_since` resets to `None` on boost lapse and to a new datetime on re-boost, so the gate restarts with every new boost streak
+3. Hasn't used the discount this month: the `users` doc field `booster_discount_month` (`"YYYY-MM"`) differs from the current `_budget_month_key()`
+
+Mechanics:
+- Discounted price is `_discounted_price(price)` = `int(price * 0.9)`. The discount is skipped when it would save less than 1 token (e.g. free items), so it can't be burned for nothing.
+- `booster_discount_month` is only stamped **after** a completed purchase — a failed balance check doesn't consume the month's discount. No reset logic is needed: a stale month key simply stops matching after rollover.
+- `/shop` previews the discount for eligible viewers: `~~5000~~ **4500** R7 tokens (10% booster discount)`.
+- The **USD redemption budget is unaffected**: the discount only reduces the token price at `/buy`; redemption still consumes the full `REDEMPTION_BUDGET_COSTS` cost.
+
+---
+
 ## Redemption Flow
 
 1. Member uses `/redeem` and selects an item they own

--- a/docs/TOKEN_SYSTEM.md
+++ b/docs/TOKEN_SYSTEM.md
@@ -1,7 +1,7 @@
 # Token System
 
 ## Overview
-R7 Tokens are the primary server currency. Members earn them passively through chat messages and via `/daily` claims. The passive listener runs on every `on_message` event and enforces a per-user cooldown tracked in an in-memory dict. Server Boosters receive a ~10% average bonus on passive token earnings, a passive XP bonus in the general channel, and a flat +20 tokens on every `/daily` claim.
+R7 Tokens are the primary server currency. Members earn them passively through chat messages and via `/daily` claims. The passive listener runs on every `on_message` event and enforces a per-user cooldown tracked in an in-memory dict. Server Boosters receive a ~10% average bonus on passive token earnings, a passive XP bonus in the general channel, a flat +20 tokens on every `/daily` claim, and a once-monthly 10% shop discount (see `ECONOMY_SHOP.md`).
 
 ---
 

--- a/docs/XP_AND_LEVELING.md
+++ b/docs/XP_AND_LEVELING.md
@@ -15,6 +15,8 @@ In the `on_message` listener (same cooldown gate as token earning):
 4. New level is derived from `new_exp` using the level formula
 5. `update_leveling_data(user_id, new_level, new_exp)` writes both back
 
+Server Boosters additionally roll a **35% chance of +1 bonus XP** per general-channel message (independent of the token cooldown).
+
 XP earning happens in the same single `on_message` handler as tokens. The two are not separate listeners — one fire updates both.
 
 ---

--- a/features/economy.py
+++ b/features/economy.py
@@ -15,6 +15,8 @@ from database.mongo import (
     get_leveling_data,
     update_leveling_data,
     add_item_token,
+    get_booster_discount_month,
+    set_booster_discount_month,
     get_item_count,
     remove_item_token,
     get_setting,
@@ -152,6 +154,39 @@ def _token_price_for_item(item_name: str) -> int:
         return int(item_cfg.get("price", 0))
     except Exception:
         return 0
+
+
+BOOSTER_DISCOUNT_RATE = 0.10
+BOOSTER_DISCOUNT_MIN_BOOST_DAYS = 14
+
+
+def _discounted_price(price: int) -> int:
+    return int(price * (1 - BOOSTER_DISCOUNT_RATE))
+
+
+def _booster_tenure_eligible(member) -> bool:
+    """Booster role held and boosting for at least the minimum streak length.
+
+    premium_since resets to None when a boost lapses, so the 14-day gate
+    restarts on every new boost streak.
+    """
+    get_role = getattr(member, "get_role", None)
+    if get_role is None or get_role(SERVER_BOOSTER_ROLE_ID) is None:
+        return False
+    premium_since = getattr(member, "premium_since", None)
+    if premium_since is None:
+        return False
+    return datetime.now(timezone.utc) - premium_since >= timedelta(
+        days=BOOSTER_DISCOUNT_MIN_BOOST_DAYS
+    )
+
+
+async def _booster_discount_available(member) -> bool:
+    """Tenure-eligible booster who hasn't used the monthly discount yet."""
+    if not _booster_tenure_eligible(member):
+        return False
+    used_month = await get_booster_discount_month(str(member.id))
+    return used_month != _budget_month_key()
 
 
 def _extract_topic_value(topic: str | None, key: str) -> str | None:
@@ -846,12 +881,15 @@ class LevelsLeaderboardView(discord.ui.View):
 
 
 class ShopPaginationView(discord.ui.View):
-    def __init__(self, data: dict, items_per_page: int = 4):
+    def __init__(
+        self, data: dict, items_per_page: int = 4, booster_discount: bool = False
+    ):
         super().__init__(timeout=60)
         self.data = list(data.items())
         self.items_per_page = items_per_page
         self.current_page = 0
         self.total_pages = (len(self.data) - 1) // items_per_page + 1
+        self.booster_discount = booster_discount
 
     def create_embed(self):
         start = self.current_page * self.items_per_page
@@ -866,9 +904,17 @@ class ShopPaginationView(discord.ui.View):
         )
 
         for key, info in page_items:
+            price = info["price"]
+            if self.booster_discount and _discounted_price(price) < price:
+                price_line = (
+                    f"**Price:** ~~{price}~~ **{_discounted_price(price)}** "
+                    "R7 tokens (10% booster discount)"
+                )
+            else:
+                price_line = f"**Price:** {price} R7 tokens"
             embed.add_field(
                 name=info["display"],
-                value=f"{info['desc']}\n**Price:** {info['price']} R7 tokens",
+                value=f"{info['desc']}\n{price_line}",
                 inline=False,
             )
         return embed
@@ -1197,8 +1243,11 @@ class Economy(commands.Cog):
 
     @app_commands.command(name="shop", description="View the R7 token shop.")
     async def shop(self, interaction: discord.Interaction):
+        discount_eligible = await _booster_discount_available(interaction.user)
         # Create the view with 4 items per page
-        view = ShopPaginationView(SHOP_DATA, items_per_page=4)
+        view = ShopPaginationView(
+            SHOP_DATA, items_per_page=4, booster_discount=discount_eligible
+        )
         view.update_buttons()
         await interaction.response.send_message(embed=view.create_embed(), view=view)
 
@@ -1225,6 +1274,15 @@ class Economy(commands.Cog):
 
         item_info = SHOP_DATA[item]
         price = item_info["price"]
+        original_price = price
+
+        # Don't burn the monthly discount on items where 10% saves nothing.
+        discount_applied = _discounted_price(
+            price
+        ) < price and await _booster_discount_available(interaction.user)
+        if discount_applied:
+            price = _discounted_price(price)
+
         balance = await get_user_balance(user_id)
 
         if balance < price:
@@ -1239,10 +1297,24 @@ class Economy(commands.Cog):
         new_balance = balance - price
         await update_user_balance(user_id, new_balance)
         await add_item_token(user_id, item)
+        if discount_applied:
+            # Marked only after a completed purchase, so a failed balance
+            # check doesn't consume the monthly discount.
+            await set_booster_discount_month(user_id, _budget_month_key())
+
+        description = (
+            f"You have purchased **{item_info['display']}**!\n"
+            "Please use `/redeem` to claim it."
+        )
+        if discount_applied:
+            description += (
+                f"\n🚀 **Booster Discount:** ~~{original_price}~~ **{price}** "
+                "R7 tokens — 10% off applied (1/month)"
+            )
 
         embed = discord.Embed(
             title="✅ **Purchase Successful**",
-            description=f"You have purchased **{item_info['display']}**!\nPlease use `/redeem` to claim it.",
+            description=description,
             color=discord.Color.green(),
         )
         embed.set_footer(text=f"Your new balance: {int(new_balance)} R7 tokens")
@@ -1826,7 +1898,9 @@ class Economy(commands.Cog):
         spend_text = (
             "🛒 **The Shop:** Use `/shop` to browse rewards like Brawl Pass, Discord Nitro, and PayPal.\n"
             "💳 **Purchasing:** Use `/buy <item>` to spend your tokens on an item.\n"
-            "🎟️ **Redeeming:** Use `/redeem <item>` to open a ticket and claim your reward from staff."
+            "🎟️ **Redeeming:** Use `/redeem <item>` to open a ticket and claim your reward from staff.\n"
+            "🚀 **Booster Discount:** Boosters of **14+ days** automatically get "
+            "**10% off** one purchase per month."
         )
         spend_embed.add_field(name="🛍️ Shopping Flow", value=spend_text, inline=False)
 

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -1,6 +1,6 @@
 """Tests for pure functions in features/economy.py."""
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import discord
@@ -12,8 +12,10 @@ from features.config import (
 )
 from features.economy import (
     Economy,
+    _booster_tenure_eligible,
     _budget_month_key,
     _budget_cost_for_item,
+    _discounted_price,
     _extract_topic_value,
     _pending_redemptions_total,
     _redemption_instructions,
@@ -72,6 +74,61 @@ def test_budget_cost_unknown_item_returns_zero():
 
 def test_token_price_unknown_item_returns_zero():
     assert _token_price_for_item("this item does not exist") == 0
+
+
+# --- _discounted_price ---
+
+
+def test_discounted_price_brawl_pass():
+    assert _discounted_price(5000) == 4500
+
+
+def test_discounted_price_small_price():
+    assert _discounted_price(500) == 450
+
+
+def test_discounted_price_truncates():
+    assert _discounted_price(55) == 49
+
+
+def test_discounted_price_zero():
+    assert _discounted_price(0) == 0
+
+
+# --- _booster_tenure_eligible ---
+
+
+class _FakeMember:
+    def __init__(self, has_role: bool, premium_since):
+        self._has_role = has_role
+        self.premium_since = premium_since
+
+    def get_role(self, role_id):
+        return MagicMock() if self._has_role else None
+
+
+def test_tenure_eligible_long_boost():
+    since = datetime.now(timezone.utc) - timedelta(days=20)
+    assert _booster_tenure_eligible(_FakeMember(True, since)) is True
+
+
+def test_tenure_ineligible_short_boost():
+    since = datetime.now(timezone.utc) - timedelta(days=5)
+    assert _booster_tenure_eligible(_FakeMember(True, since)) is False
+
+
+def test_tenure_ineligible_no_premium_since():
+    assert _booster_tenure_eligible(_FakeMember(True, None)) is False
+
+
+def test_tenure_ineligible_without_role():
+    since = datetime.now(timezone.utc) - timedelta(days=20)
+    assert _booster_tenure_eligible(_FakeMember(False, since)) is False
+
+
+def test_tenure_ineligible_non_member_user():
+    # Users outside a guild (e.g. DMs) have no get_role/premium_since.
+    assert _booster_tenure_eligible(object()) is False
 
 
 # --- _extract_topic_value ---


### PR DESCRIPTION
### Changes
* Added a 10% booster discount on one shop purchase per calendar month, applied automatically in `/buy`: eligibility requires the Server Booster role and `member.premium_since` at least 14 days ago, the discounted price is used for the balance check and deduction, and the claim embed shows `~~original~~ discounted` when applied
* Added per-user usage tracking via a `booster_discount_month` ("YYYY-MM") field on the `users` doc with `get_booster_discount_month`/`set_booster_discount_month` helpers in `database/mongo.py` — the month is only stamped after a completed purchase, and rollover is implicit (stored key stops matching the current month)
* Updated `/shop` to preview discounted prices with strikethrough originals for eligible boosters (`ShopPaginationView` gained a `booster_discount` flag)
* Added `_discounted_price`, `_booster_tenure_eligible`, and `_booster_discount_available` helpers in `features/economy.py`; the discount is skipped when 10% would save less than 1 token so it can't be burned on free items
* Added unit tests for the discount math and tenure eligibility in `tests/test_economy.py`
* Updated `/economy` help embed and docs (`ECONOMY_SHOP.md`, `DATABASE.md`, `TOKEN_SYSTEM.md`) to document the new perk

### Notes
* The $50 USD monthly redemption budget is intentionally untouched: the discount only reduces the token price at `/buy`; `/redeem` still consumes the full `REDEMPTION_BUDGET_COSTS` cost
* Closed two doc gaps left by #346: added `SERVER_BOOSTER_ROLE_ID` to the `CONFIG_SYSTEM.md` role table and the booster XP bonus to `XP_AND_LEVELING.md`
* Accepted edge: two simultaneous `/buy`s from the same booster could both receive the discount (no lock — negligible for a once-monthly token perk)

<details>
<summary><h3>Screenshots</h3></summary>

Discounted Shop:
<img width="376" height="381" alt=") RemainingDelta  R7 used  shop-discount-preview" src="https://github.com/user-attachments/assets/d6a554c6-25f0-4548-a322-eb2478d9bd97" />


</details>

Closes #347
