### PR TITLE
348-Feature add booster reduced quest thresholds stored at assignment

### DIFF
--- a/database/mongo.py
+++ b/database/mongo.py
@@ -848,10 +848,20 @@ async def get_active_quest(user_id: str, q_key: str):
     return quest_entry
 
 
-async def assign_random_quest(user_id: str, q_key: str):
+BOOSTER_QUEST_TARGET_MULTIPLIER = 0.8
+
+
+def booster_quest_target(target: int) -> int:
+    """Returns the reduced quest target for server boosters (20% off)."""
+    return max(1, round(target * BOOSTER_QUEST_TARGET_MULTIPLIER))
+
+
+async def assign_random_quest(user_id: str, q_key: str, is_booster: bool = False):
     """Picks a random active quest from the DB and assigns it to the user.
 
     q_key is one of: daily_message, weekly_message, daily_megabox, weekly_megabox
+    Boosters get a reduced target, stored on the assignment record so the
+    threshold is fixed for the quest's lifetime regardless of boost changes.
     """
     if db is None:
         return None
@@ -876,15 +886,23 @@ async def assign_random_quest(user_id: str, q_key: str):
 
     quest = random.choice(matching_quests)
 
+    target = quest.get("target_count", quest.get("target", 100))
+    description = quest["description"]
+    if is_booster:
+        reduced = booster_quest_target(target)
+        description = description.replace(str(target), str(reduced), 1)
+        target = reduced
+
     new_entry = {
         "quest_id": quest["_id"],
         "name": quest["name"],
-        "description": quest["description"],
-        "target_count": quest.get("target_count", quest.get("target", 100)),
+        "description": description,
+        "target_count": target,
         "reward_tokens": quest.get("reward_tokens", 0),
         "reward_exp": quest.get("reward_exp", 0),
         "progress": 0,
         "completed": False,
+        "booster_reduced": is_booster,
         "date_assigned": datetime.utcnow(),
     }
 

--- a/docs/QUEST_SYSTEM.md
+++ b/docs/QUEST_SYSTEM.md
@@ -22,6 +22,25 @@ Defined in `DEFAULT_QUESTS` inside `features/quests.py` and seeded into the `que
 
 ---
 
+## Booster Threshold Reduction
+
+Server boosters (holders of `SERVER_BOOSTER_ROLE_ID`) get a **20% reduced target** on all quest types:
+
+| Quest | Base Target | Booster Target |
+|-------|-------------|----------------|
+| Daily Chatter / Quick Convo / Engaged Today | 80 / 160 / 240 | 64 / 128 / 192 |
+| Mega Box Maniac (daily) | 100 | 80 |
+| Weekly Regular / Consistent Contributor / Server Pillar | 500 / 750 / 1000 | 400 / 600 / 800 |
+| Mega Box Grinder (weekly) | 500 | 400 |
+
+Mechanics:
+- The booster role is checked **at assignment time** inside `assign_random_quest(user_id, q_key, is_booster)`. The reduced target (and a description rewritten with the reduced count) is stored on the `user_quests` record along with a `booster_reduced` flag — it is **not** recomputed at progress-check time.
+- Because assignment is lazy (expired quests reassign on the next message/box open/`/quests`), reductions take effect at the **next quest cycle** after boosting, and revert to standard targets at the next cycle after the boost lapses. An in-flight quest keeps its stored target either way.
+- `/reset-quests` deletes the user's quest doc, so the forced reassignment re-evaluates booster status at that moment.
+- Reduction math: `booster_quest_target()` in `database/mongo.py` (`max(1, round(target * 0.8))`).
+
+---
+
 ## Progress Tracking
 
 `process_quest_update(user_id, channel, action_type)` is called from:

--- a/features/brawl/commands.py
+++ b/features/brawl/commands.py
@@ -704,7 +704,7 @@ class BrawlCommands(commands.Cog):
         quests_cog = self.bot.get_cog("Quests")
         if quests_cog:
             await quests_cog.process_quest_update(
-                user_id, interaction.channel, "megabox"
+                user_id, interaction.channel, "megabox", member=interaction.user
             )
 
     @app_commands.command(name="starrdrop", description="Open a random Starr Drop!")
@@ -738,7 +738,7 @@ class BrawlCommands(commands.Cog):
         quests_cog = self.bot.get_cog("Quests")
         if quests_cog:
             await quests_cog.process_quest_update(
-                user_id, interaction.channel, "megabox"
+                user_id, interaction.channel, "megabox", member=interaction.user
             )
 
     @app_commands.command(

--- a/features/quests.py
+++ b/features/quests.py
@@ -7,6 +7,7 @@ from features.config import (
     BOTS_CATEGORY_ID,
     GENERAL_CHANNEL_ID,
     PASSIVE_REWARD_EXCLUDED_CHANNEL_IDS,
+    SERVER_BOOSTER_ROLE_ID,
 )
 
 # Import Database Helpers
@@ -80,6 +81,12 @@ DEFAULT_QUESTS = [
 ]
 
 
+def _is_booster(member) -> bool:
+    """Booster role check; safe against non-Member objects (DMs, None)."""
+    get_role = getattr(member, "get_role", None)
+    return get_role is not None and get_role(SERVER_BOOSTER_ROLE_ID) is not None
+
+
 class Quests(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -103,7 +110,9 @@ class Quests(commands.Cog):
 
     # --- HELPERS ---
 
-    async def process_quest_update(self, user_id, channel, action_type="message"):
+    async def process_quest_update(
+        self, user_id, channel, action_type="message", member=None
+    ):
         """Checks daily/weekly quests for progress."""
         if action_type == "message":
             q_keys = ["daily_message", "weekly_message"]
@@ -116,7 +125,9 @@ class Quests(commands.Cog):
             # 1. Get or Assign Quest
             quest = await get_active_quest(user_id, q_key)
             if not quest:
-                quest = await assign_random_quest(user_id, q_key)
+                quest = await assign_random_quest(
+                    user_id, q_key, is_booster=_is_booster(member)
+                )
 
             if not quest:
                 continue
@@ -169,7 +180,7 @@ class Quests(commands.Cog):
 
         # Trigger message quest updates
         await self.process_quest_update(
-            str(message.author.id), message.channel, "message"
+            str(message.author.id), message.channel, "message", member=message.author
         )
 
     # Kept to prevent errors if main.py expects them, but they do nothing for quests now
@@ -218,7 +229,9 @@ class Quests(commands.Cog):
         for q_key, title in quest_slots:
             quest = await get_active_quest(user_id, q_key)
             if not quest:
-                quest = await assign_random_quest(user_id, q_key)
+                quest = await assign_random_quest(
+                    user_id, q_key, is_booster=_is_booster(interaction.user)
+                )
 
             if quest:
                 # Progress Bar Logic

--- a/tests/test_quests.py
+++ b/tests/test_quests.py
@@ -1,0 +1,59 @@
+"""Tests for pure functions in the quest system (booster threshold reduction)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from database.mongo import booster_quest_target
+from features.config import SERVER_BOOSTER_ROLE_ID
+from features.quests import _is_booster
+
+
+# --- booster_quest_target ---
+
+
+@pytest.mark.parametrize(
+    "base,expected",
+    [
+        (80, 64),
+        (160, 128),
+        (240, 192),
+        (100, 80),
+        (500, 400),
+        (750, 600),
+        (1000, 800),
+    ],
+)
+def test_booster_quest_target_matches_spec(base, expected):
+    assert booster_quest_target(base) == expected
+
+
+def test_booster_quest_target_never_below_one():
+    assert booster_quest_target(1) == 1
+    assert booster_quest_target(0) == 1
+
+
+# --- _is_booster ---
+
+
+def _member_with_roles(role_ids):
+    member = MagicMock()
+    member.get_role = lambda rid: MagicMock() if rid in role_ids else None
+    return member
+
+
+def test_is_booster_true_with_role():
+    assert _is_booster(_member_with_roles({SERVER_BOOSTER_ROLE_ID})) is True
+
+
+def test_is_booster_false_without_role():
+    assert _is_booster(_member_with_roles(set())) is False
+
+
+def test_is_booster_false_for_none_member():
+    assert _is_booster(None) is False
+
+
+def test_is_booster_false_for_user_without_get_role():
+    user = object()  # discord.User in DMs has no get_role
+    assert _is_booster(user) is False


### PR DESCRIPTION
### Changes
* Added a 20% quest threshold reduction for Server Boosters across all four quest types: daily message (64/128/192), weekly message (400/600/800), daily megabox (80), weekly megabox (400)
* Added `is_booster` param to `assign_random_quest()` in `database/mongo.py` — the reduced target is computed via a new `booster_quest_target()` helper and stored on the quest record at assignment time (with a `booster_reduced` flag and the description rewritten to show the reduced count), never recomputed at check time
* Updated `process_quest_update()` and the `/quests` assignment path in `features/quests.py` to check the Booster role via a new `_is_booster()` helper; `/megabox` and `/starrdrop` in `features/brawl/commands.py` now pass the member through for megabox quest assignments
* Reductions take effect at the next quest cycle after boosting and revert at the next cycle after a lapse (existing lazy reassignment on expiry); `/reset-quests` re-evaluates booster status on forced reassignment
* Added `tests/test_quests.py` covering the reduced targets and the booster role check, and documented the mechanic in `docs/QUEST_SYSTEM.md`

Closes #348
