### PR TITLE
359-Feature add moderator message link mirror via webhook

### DIFF
--- a/docs/MESSAGE_MIRROR.md
+++ b/docs/MESSAGE_MIRROR.md
@@ -1,0 +1,41 @@
+# Message Mirror
+
+## Overview
+Lets moderators repost any message via webhook so it renders with the original author's username and avatar. A moderator pastes a Discord message link in a channel; the bot fetches the linked message and mirrors it in that channel through a temporary webhook. The moderator's link message is left in place. General utility — usable for booster shoutouts or any repost need.
+
+---
+
+## Trigger Conditions
+
+The `on_message` listener mirrors only when **all** of these hold:
+
+1. Author is not a bot and the message is in a guild
+2. Author has the **Moderator role** (`MODERATOR_ROLE_ID`) — non-moderators are unaffected
+3. The message content is **exactly one** Discord message link (surrounding whitespace allowed). A link inside a sentence does not trigger, so conversational messages containing links are never mirrored
+4. The channel supports webhooks (threads and voice channels are skipped)
+
+Accepted link formats: `discord.com`, `ptb.discord.com`, `canary.discord.com`, `discordapp.com` — all matching `/channels/<guild_id>/<channel_id>/<message_id>`.
+
+---
+
+## Mirror Flow
+
+1. `_parse_message_link()` extracts `(guild_id, channel_id, message_id)`
+2. The linked message is fetched via `bot.get_channel()` (falling back to `fetch_channel()`) then `channel.fetch_message()`. If the message can't be fetched (deleted, no access), the listener silently does nothing
+3. `_strip_mentions()` removes all user (`<@id>`, `<@!id>`) and role (`<@&id>`) mention tokens from the content. Channel mentions (`<#id>`) are kept since they don't ping. Leftover doubled spaces are collapsed; leading indentation (code blocks) is preserved
+4. Attachment URLs are appended on separate lines so images re-embed; content is truncated to the 2000-char webhook limit. If the source has no content and no attachments, nothing is posted
+5. A webhook named `R7 Message Mirror` is created in the channel, sends with `username=source.author.display_name` and `avatar_url=source.author.display_avatar.url`, then is **deleted** (channels cap at 15 webhooks)
+6. The webhook send also passes `allowed_mentions=AllowedMentions.none()` as a second layer against pings
+
+---
+
+## Permissions Required (bot)
+
+- **Manage Webhooks** in the target channel (create/delete the webhook)
+
+Failures on any Discord call are swallowed (`HTTPException`) — the feature degrades silently rather than erroring in chat.
+
+---
+
+## Source File
+`features/message_mirror.py` — tests in `tests/test_message_mirror.py`

--- a/features/message_mirror.py
+++ b/features/message_mirror.py
@@ -1,0 +1,119 @@
+import re
+
+import discord
+from discord.ext import commands
+
+from features.config import MODERATOR_ROLE_ID
+
+
+# Matches a full Discord message link: guild_id / channel_id / message_id
+MESSAGE_LINK_PATTERN = re.compile(
+    r"https://(?:ptb\.|canary\.)?discord(?:app)?\.com"
+    r"/channels/(\d+)/(\d+)/(\d+)"
+)
+
+USER_MENTION_PATTERN = re.compile(r"<@!?\d+>")
+ROLE_MENTION_PATTERN = re.compile(r"<@&\d+>")
+
+WEBHOOK_NAME = "R7 Message Mirror"
+MAX_MESSAGE_LENGTH = 2000
+
+
+def _parse_message_link(content: str) -> tuple[int, int, int] | None:
+    """Returns (guild_id, channel_id, message_id) if the content is exactly
+    one Discord message link, else None.
+
+    Requiring the message to be only a link (not a link inside a sentence)
+    keeps the listener from deleting conversational messages.
+    """
+    match = MESSAGE_LINK_PATTERN.fullmatch(content.strip())
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def _strip_mentions(text: str) -> str:
+    """Removes user and role mention tokens so the mirror can't ping anyone."""
+    text = USER_MENTION_PATTERN.sub("", text)
+    text = ROLE_MENTION_PATTERN.sub("", text)
+    # Clean up spaces left behind by removed tokens; leading indentation
+    # (e.g. inside code blocks) is preserved
+    text = re.sub(r" {2,}", " ", text)
+    text = re.sub(r" +\n", "\n", text)
+    return text.strip()
+
+
+class MessageMirror(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def _fetch_linked_message(
+        self, channel_id: int, message_id: int
+    ) -> discord.Message | None:
+        channel = self.bot.get_channel(channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(channel_id)
+            except discord.HTTPException:
+                return None
+        try:
+            return await channel.fetch_message(message_id)
+        except (discord.HTTPException, AttributeError):
+            return None
+
+    def _build_mirror_content(self, source: discord.Message) -> str:
+        content = _strip_mentions(source.content or "")
+        attachment_urls = [a.url for a in source.attachments]
+        if attachment_urls:
+            urls = "\n".join(attachment_urls)
+            content = f"{content}\n{urls}" if content else urls
+        return content[:MAX_MESSAGE_LENGTH]
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if message.author.bot or message.guild is None:
+            return
+
+        link = _parse_message_link(message.content)
+        if link is None:
+            return
+        _, channel_id, message_id = link
+
+        if message.author.get_role(MODERATOR_ROLE_ID) is None:
+            return
+
+        # Threads and voice channels can't own webhooks
+        if not hasattr(message.channel, "create_webhook"):
+            return
+
+        source = await self._fetch_linked_message(channel_id, message_id)
+        if source is None:
+            return
+
+        content = self._build_mirror_content(source)
+        if not content:
+            return
+
+        try:
+            webhook = await message.channel.create_webhook(name=WEBHOOK_NAME)
+        except discord.HTTPException:
+            return
+
+        try:
+            await webhook.send(
+                content=content,
+                username=source.author.display_name,
+                avatar_url=source.author.display_avatar.url,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        except discord.HTTPException:
+            pass
+        finally:
+            try:
+                await webhook.delete()
+            except discord.HTTPException:
+                pass
+
+
+async def setup(bot):
+    await bot.add_cog(MessageMirror(bot))

--- a/main.py
+++ b/main.py
@@ -79,6 +79,9 @@ async def on_ready():
         await bot.load_extension("features.counting")
         print("✅ Loaded Feature: Counting")
 
+        await bot.load_extension("features.message_mirror")
+        print("✅ Loaded Feature: Message Mirror")
+
         await bot.load_extension("features.tourney.tourney_reports")
         print("✅ Loaded Feature: Tourney Reports")
 

--- a/tests/test_message_mirror.py
+++ b/tests/test_message_mirror.py
@@ -1,0 +1,63 @@
+from features.message_mirror import _parse_message_link, _strip_mentions
+
+
+LINK = "https://discord.com/channels/111/222/333"
+
+
+class TestParseMessageLink:
+    def test_plain_link(self):
+        assert _parse_message_link(LINK) == (111, 222, 333)
+
+    def test_link_with_surrounding_whitespace(self):
+        assert _parse_message_link(f"  {LINK}\n") == (111, 222, 333)
+
+    def test_ptb_and_canary_links(self):
+        assert _parse_message_link("https://ptb.discord.com/channels/1/2/3") == (
+            1,
+            2,
+            3,
+        )
+        assert _parse_message_link("https://canary.discord.com/channels/1/2/3") == (
+            1,
+            2,
+            3,
+        )
+
+    def test_discordapp_domain(self):
+        assert _parse_message_link("https://discordapp.com/channels/1/2/3") == (1, 2, 3)
+
+    def test_link_inside_sentence_is_ignored(self):
+        assert _parse_message_link(f"check this out {LINK}") is None
+
+    def test_channel_link_is_ignored(self):
+        assert _parse_message_link("https://discord.com/channels/111/222") is None
+
+    def test_plain_text_is_ignored(self):
+        assert _parse_message_link("hello world") is None
+
+    def test_empty_content(self):
+        assert _parse_message_link("") is None
+
+
+class TestStripMentions:
+    def test_user_mention_removed(self):
+        assert _strip_mentions("hey <@123456> welcome") == "hey welcome"
+
+    def test_nickname_mention_removed(self):
+        assert _strip_mentions("hey <@!123456> welcome") == "hey welcome"
+
+    def test_role_mention_removed(self):
+        assert _strip_mentions("attention <@&987654> members") == "attention members"
+
+    def test_multiple_mentions_removed(self):
+        assert _strip_mentions("<@1> <@!2> <@&3> done") == "done"
+
+    def test_text_without_mentions_unchanged(self):
+        assert _strip_mentions("no mentions here") == "no mentions here"
+
+    def test_newlines_preserved(self):
+        assert _strip_mentions("line one <@1>\nline two") == "line one\nline two"
+
+    def test_channel_mention_kept(self):
+        # Channel mentions don't ping anyone, so they stay
+        assert _strip_mentions("see <#555>") == "see <#555>"


### PR DESCRIPTION
### Changes
* Added `features/message_mirror.py`: when a member with the Moderator role posts a Discord message link on its own, the bot fetches the linked message and reposts it in the same channel via a temporary webhook using the original author's display name and avatar
* Added mention safety: user and role mention tokens are stripped from the mirrored content and the webhook sends with `AllowedMentions.none()`, so the mirror can never ping
* Added attachment support: attachment URLs are appended so images re-embed; content is truncated to the 2000-char webhook limit
* Registered the Message Mirror cog in `main.py`
* Added `tests/test_message_mirror.py` covering link parsing (all four Discord link domains, links inside sentences ignored) and mention stripping
* Added `docs/MESSAGE_MIRROR.md` documenting trigger conditions, mirror flow, and required bot permissions

### Notes
* Deviation from the issue spec: the moderator's original link message is **kept**, not deleted (changed during review) — the bot therefore only needs Manage Webhooks, not Manage Messages
* The trigger requires the message to be *exactly* one message link, so links pasted mid-sentence never trigger a mirror
* Links to servers the bot is not in (and DM links) are silently ignored — Discord bots can only fetch messages from guilds they're a member of

<details>
<summary><h3>Screenshots</h3></summary>

Feature in action:
<img width="249" height="116" alt="RemainingDelta" src="https://github.com/user-attachments/assets/c1f2c3bb-72b1-49a6-9321-2c19e36ba1f9" />

</details>

Closes #359
