### PR TITLE
351-Feature add booster perks slash command

### DIFF
--- a/docs/BOOSTER_SHOUTOUT.md
+++ b/docs/BOOSTER_SHOUTOUT.md
@@ -5,6 +5,8 @@ When a member starts boosting the server, the bot automatically opens a private 
 
 Source: `features/booster_shoutout.py`
 
+> When changing this perk, also update the `/booster-perks` embed in `features/general.py`.
+
 ---
 
 ## Boost Detection

--- a/docs/ECONOMY_SHOP.md
+++ b/docs/ECONOMY_SHOP.md
@@ -49,6 +49,8 @@ Mechanics:
 - `/shop` previews the discount for eligible viewers: `~~5000~~ **4500** R7 tokens (10% booster discount)`.
 - The **USD redemption budget is unaffected**: the discount only reduces the token price at `/buy`; redemption still consumes the full `REDEMPTION_BUDGET_COSTS` cost.
 
+> When changing this perk, also update the `/booster-perks` embed in `features/general.py`.
+
 ---
 
 ## Redemption Flow

--- a/docs/QUEST_SYSTEM.md
+++ b/docs/QUEST_SYSTEM.md
@@ -39,6 +39,8 @@ Mechanics:
 - `/reset-quests` deletes the user's quest doc, so the forced reassignment re-evaluates booster status at that moment.
 - Reduction math: `booster_quest_target()` in `database/mongo.py` (`max(1, round(target * 0.8))`).
 
+> When changing this perk, also update the `/booster-perks` embed in `features/general.py`.
+
 ---
 
 ## Progress Tracking

--- a/docs/TOKEN_SYSTEM.md
+++ b/docs/TOKEN_SYSTEM.md
@@ -3,6 +3,8 @@
 ## Overview
 R7 Tokens are the primary server currency. Members earn them passively through chat messages and via `/daily` claims. The passive listener runs on every `on_message` event and enforces a per-user cooldown tracked in an in-memory dict. Server Boosters receive a ~10% average bonus on passive token earnings, a passive XP bonus in the general channel, a flat +20 tokens on every `/daily` claim, and a once-monthly 10% shop discount (see `ECONOMY_SHOP.md`).
 
+> When changing any booster perk here, also update the `/booster-perks` embed in `features/general.py`.
+
 ---
 
 ## Passive Earning

--- a/docs/XP_AND_LEVELING.md
+++ b/docs/XP_AND_LEVELING.md
@@ -15,7 +15,7 @@ In the `on_message` listener (same cooldown gate as token earning):
 4. New level is derived from `new_exp` using the level formula
 5. `update_leveling_data(user_id, new_level, new_exp)` writes both back
 
-Server Boosters additionally roll a **35% chance of +1 bonus XP** per general-channel message (independent of the token cooldown).
+Server Boosters additionally roll a **35% chance of +1 bonus XP** per general-channel message (independent of the token cooldown). When changing this perk, also update the `/booster-perks` embed in `features/general.py`.
 
 XP earning happens in the same single `on_message` handler as tokens. The two are not separate listeners — one fire updates both.
 

--- a/features/general.py
+++ b/features/general.py
@@ -4,7 +4,13 @@ from discord.ext import commands
 from datetime import datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from features.config import ADMIN_ROLE_ID, MODERATOR_ROLE_ID, BOT_VERSION
+from features.config import (
+    ADMIN_ROLE_ID,
+    BOOSTER_CHANNEL_ID,
+    BOT_VERSION,
+    GENERAL_CHANNEL_ID,
+    MODERATOR_ROLE_ID,
+)
 
 
 class General(commands.Cog):
@@ -69,6 +75,7 @@ class General(commands.Cog):
         embed.add_field(name="🔢 Counting Game", value=counting_text, inline=False)
 
         utility_text = (
+            "`/booster-perks` - View all Server Booster perks\n"
             "`/convert-time` - Convert a date and time to Discord timestamp formats\n"
             "`/version` - View the bot's current version"
         )
@@ -225,6 +232,44 @@ class General(commands.Cog):
         "AEDT": "Australia/Sydney",
         "BRT": "America/Sao_Paulo",
     }
+
+    # NOTE: Keep this embed in sync with the actual perks — update it whenever a
+    # booster perk is added, modified, or removed anywhere in the bot.
+    @app_commands.command(
+        name="booster-perks",
+        description="View all perks for Server Boosters.",
+    )
+    async def booster_perks(self, interaction: discord.Interaction):
+        general_ch = f"<#{GENERAL_CHANNEL_ID}>"
+        booster_ch = f"<#{BOOSTER_CHANNEL_ID}>"
+
+        perks_text = (
+            "Boost the server to unlock all of the perks below. "
+            "Thank you for supporting R7! 💖\n\n"
+            f"🔓 **Exclusive Channel:** Access to {booster_ch} — supply-drop crates "
+            "(**10-25 tokens**) land there every ~2 hours on average, first to click claims it.\n"
+            f"💰 **Token Bonus:** ~10% more tokens on average in {general_ch} and the booster channel.\n"
+            f"✨ **XP Bonus:** 35% chance of +1 bonus XP per message in {general_ch} and the booster channel.\n"
+            "📅 **Daily Bonus:** Flat **+20 tokens** on every `/daily` claim.\n"
+            "📜 **Easier Quests:** Daily/weekly quest targets reduced by **20%** "
+            "*(applies from your next quest cycle after boosting)*.\n"
+            "📣 **Booster Shoutout:** A private ticket opens when you boost — write a message "
+            "for staff to review and feature in announcements once approved "
+            "*(self-promo and similar are not allowed)*. *(Once per calendar month.)*\n"
+            "🛒 **Shop Discount:** **10% off** one shop purchase per calendar month via `/buy` "
+            "*(unlocks after **14+ consecutive days** of boosting)*."
+        )
+
+        embed = discord.Embed(
+            title="🚀 **Server Booster Perks**",
+            description=perks_text,
+            color=discord.Color.fuchsia(),
+        )
+
+        embed.set_footer(text="Perks apply while your boost is active.")
+        embed.set_thumbnail(url=self.bot.user.display_avatar.url)
+
+        await interaction.response.send_message(embed=embed)
 
     @app_commands.command(name="version", description="View the bot's current version.")
     async def version(self, interaction: discord.Interaction):


### PR DESCRIPTION
### Changes
* Added `/booster-perks` command showing all Server Booster perks in one embed
* Added sync reminders across 5 booster-perk docs to keep the embed updated

<details>
<summary><h3>Screenshots</h3></summary>

New command detailing the perks:
<img width="532" height="455" alt="image" src="https://github.com/user-attachments/assets/1ab610d9-e00d-40db-8108-071ac4fb17c3" />

</details>


Closes #351
