### PR TITLE
354-Enhancement remove Tourney Admin from staff application role options

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Every user always has **4 active quests** — one daily and one weekly per categ
 - **Ticket Types:**
   - Report an Issue — bugs, rule violations, technical problems.
   - Server Support — general server assistance.
-  - Staff Application — apply for Tourney Admin or Event Staff.
+  - Staff Application — apply for Event Staff (Tourney Admin / Moderator closed).
   - Server Partnership — propose a partnership.
 - One open ticket per type per user.
 - Staff can close, reopen, and delete tickets with transcript generation.

--- a/docs/SUPPORT_TICKETS.md
+++ b/docs/SUPPORT_TICKETS.md
@@ -11,7 +11,7 @@ The support ticket system provides four types of private help channels for membe
 |----------|------|---------|---------|
 | `bug` | Report an Issue | Bugs, violations, technical problems | Separate issue category |
 | `support` | Server Support | General assistance | Separate support category |
-| `staff_app` | Staff Application | Tourney Admin / Event Staff applications | Separate applications category |
+| `staff_app` | Staff Application | Event Staff applications (Tourney Admin / Moderator closed, shown struck through) | Separate applications category |
 | `partnership` | Server Partnership | Partnership proposals | Separate partnership category |
 
 ---

--- a/features/support_tickets.py
+++ b/features/support_tickets.py
@@ -48,7 +48,7 @@ TICKET_TYPES = {
         "category_id": SUPPORT_STAFF_APPS_CATEGORY_ID,
         "open_message": (
             "**Which position do you want to apply for:**\n"
-            "**Tourney Admin** - Run Matcherino tournaments and manage support tickets\n"
+            "~~**Tourney Admin** - Run Matcherino tournaments and manage support tickets~~\n"
             "**Event Staff** - Bring our community together by hosting fun, engaging events\n"
             "~~**Moderator** - Monitor chats, assist members, and enforce server rules fairly~~\n\n"
             "Then please present your reasons for why we should accept you.\n\n"
@@ -639,7 +639,7 @@ class SupportTickets(commands.Cog):
                 "**Available categories:**\n"
                 "🔧 **Report an Issue** — Bugs, rule-break reports, or technical problems\n"
                 "🛡️ **Server Support** — General assistance for the server\n"
-                f"📋 **Staff Application** — Apply for **Tourney Admin** or **Event Staff** (**No Moderator** spots currently open). More info: {staff_info}\n"
+                f"📋 **Staff Application** — Apply for **Event Staff** (**No Tourney Admin or Moderator** spots currently open). More info: {staff_info}\n"
                 "🤝 **Server Partnership** — Propose a partnership with your server details and goals\n\n"
                 "⚠️ **Tourney tickets opened here will not be prioritised and may go unanswered.**\n"
                 f"For tourney-related concerns, go to {tourney_ch}"


### PR DESCRIPTION
### Changes
  * Removed `Tourney Admin` from `/support-panel` staff application options
  * Struck through `Tourney Admin` in the ticket-creation prompt, like `Moderator`
  * Updated README and SUPPORT_TICKETS.md to note both closed positions

  Closes #354