### PR TITLE
353-Bug fix XP earning outside general and booster channels

### DIFF
--- a/docs/TOKEN_SYSTEM.md
+++ b/docs/TOKEN_SYSTEM.md
@@ -9,7 +9,7 @@ R7 Tokens are the primary server currency. Members earn them passively through c
 
 ## Passive Earning
 
-The `on_message` listener in `features/economy.py` fires on every message. Token earning, daily message count tracking, and quest progress apply identically in the general channel (`GENERAL_CHANNEL_ID`) and the booster-only channel (`BOOSTER_CHANNEL_ID`, `#general-plus`):
+The `on_message` listener in `features/economy.py` fires on every message. Token earning, XP earning, daily message count tracking, and quest progress apply identically in the general channel (`GENERAL_CHANNEL_ID`) and the booster-only channel (`BOOSTER_CHANNEL_ID`, `#general-plus`) — no rewards are granted outside these two channels:
 
 1. Ignores bots, DMs, and channels in `PASSIVE_REWARD_EXCLUDED_CHANNEL_IDS`
 2. Enforces a **20-second cooldown** per user via `_cooldowns: dict[int, float]` mapping `user_id → last_earn_timestamp`

--- a/docs/XP_AND_LEVELING.md
+++ b/docs/XP_AND_LEVELING.md
@@ -1,21 +1,21 @@
 # XP and Leveling
 
 ## Overview
-XP is earned alongside tokens on every message (same `on_message` listener, same 20-second cooldown). Level is derived from cumulative XP using a formula — it is not stored as a separate counter that increments discretely. Higher level increases the daily token reward.
+XP is earned alongside tokens in the same `on_message` listener, restricted to the same channels as passive token earning — the general chat channel (`GENERAL_CHANNEL_ID`) and the booster-only channel (`BOOSTER_CHANNEL_ID`). Level is derived from cumulative XP using a formula — it is not stored as a separate counter that increments discretely. Higher level increases the daily token reward.
 
 ---
 
 ## XP Earning
 
-In the `on_message` listener (same cooldown gate as token earning):
+In the `on_message` listener, gated by the same channel restriction as token earning (not the 20-second token cooldown — XP accrues on every qualifying message):
 
-1. A random XP amount is chosen (exact range defined in the listener, similar to token range)
+1. A flat `EXP_PER_MESSAGE = 10` is awarded
 2. `get_leveling_data(user_id)` fetches `(level, exp)` from the `users` collection
 3. New XP total is calculated: `new_exp = exp + xp_gained`
 4. New level is derived from `new_exp` using the level formula
 5. `update_leveling_data(user_id, new_level, new_exp)` writes both back
 
-Server Boosters additionally roll a **35% chance of +1 bonus XP** per general-channel message (independent of the token cooldown). When changing this perk, also update the `/booster-perks` embed in `features/general.py`.
+Server Boosters additionally roll a **35% chance of +1 bonus XP** per general/booster-channel message (independent of the token cooldown). When changing this perk, also update the `/booster-perks` embed in `features/general.py`.
 
 XP earning happens in the same single `on_message` handler as tokens. The two are not separate listeners — one fire updates both.
 

--- a/features/economy.py
+++ b/features/economy.py
@@ -1160,37 +1160,37 @@ class Economy(commands.Cog):
                 await update_user_balance(user_id, current_balance + earned_tokens)
                 await set_setting(f"last_message_{user_id}", str(current_timestamp))
 
-        # --- PART 2: XP & LEVELING (EVERY MESSAGE) ---
-        EXP_PER_MESSAGE = 10
-        BASE_EXP = 100
+            # --- PART 2: XP & LEVELING ---
+            EXP_PER_MESSAGE = 10
+            BASE_EXP = 100
 
-        level, exp = await get_leveling_data(user_id)
-        exp += EXP_PER_MESSAGE + booster_xp_bonus
+            level, exp = await get_leveling_data(user_id)
+            exp += EXP_PER_MESSAGE + booster_xp_bonus
 
-        while True:
-            required_exp = int(BASE_EXP * (1.5 ** (level - 1)))
-            if exp >= required_exp:
-                exp -= required_exp
-                level += 1
+            while True:
+                required_exp = int(BASE_EXP * (1.5 ** (level - 1)))
+                if exp >= required_exp:
+                    exp -= required_exp
+                    level += 1
 
-                embed = discord.Embed(
-                    title="🎉 Level Up!",
-                    description=f"{message.author.mention}, you reached **Level {level}**!",
-                    color=discord.Color.green(),
-                )
-                embed.add_field(
-                    name="Bonus",
-                    value="Daily rewards increased by **5%**!",
-                    inline=False,
-                )
-                try:
-                    await message.channel.send(embed=embed)
-                except discord.Forbidden:
-                    pass  # Ignore if bot can't send in that channel
-            else:
-                break
+                    embed = discord.Embed(
+                        title="🎉 Level Up!",
+                        description=f"{message.author.mention}, you reached **Level {level}**!",
+                        color=discord.Color.green(),
+                    )
+                    embed.add_field(
+                        name="Bonus",
+                        value="Daily rewards increased by **5%**!",
+                        inline=False,
+                    )
+                    try:
+                        await message.channel.send(embed=embed)
+                    except discord.Forbidden:
+                        pass  # Ignore if bot can't send in that channel
+                else:
+                    break
 
-        await update_leveling_data(user_id, level, exp)
+            await update_leveling_data(user_id, level, exp)
 
     # --- AUTO DROP TASK ---
     @tasks.loop(hours=6)


### PR DESCRIPTION
### Changes
* Fixed `on_message` in `features/economy.py` so XP/leveling only awards in the general chat and booster channels, matching the token-earning restriction (was previously granted in every non-excluded channel)
* Updated `docs/XP_AND_LEVELING.md` and `docs/TOKEN_SYSTEM.md` to reflect the channel-gated XP behavior

Closes #353