### PR TITLE
366-Enhancement update token shop prices to 2000 tokens per dollar

### DIFF
--- a/docs/ECONOMY_SHOP.md
+++ b/docs/ECONOMY_SHOP.md
@@ -21,8 +21,8 @@ Token prices are read via `_token_price_for_item(item_name)`. USD budget costs p
 
 ```python
 REDEMPTION_BUDGET_COSTS = {
-    "brawl pass": 10.0,
-    "brawl pass+": 15.0,
+    "brawl pass": 9.0,
+    "brawl pass+": 13.0,
     "coc gold pass": 7.0,
     "cr diamond pass": 12.0,
     "nitro": 10.0,

--- a/features/config.py
+++ b/features/config.py
@@ -398,37 +398,37 @@ SHOP_DATA = {
     "brawl pass": {
         "display": "🎮 **Brawl Pass**",
         "desc": "Unlock exclusive rewards in Brawl Stars!",
-        "price": 15300,
+        "price": 18000,
     },
     "brawl pass+": {
         "display": "💎 **Brawl Pass+**",
         "desc": "Unlock even more exclusive rewards in Brawl Stars!",
-        "price": 22100,
+        "price": 26000,
     },
     "coc gold pass": {
         "display": "🛡️ **Clash of Clans Gold Pass**",
         "desc": "Unlock the Gold Pass for the current season!",
-        "price": 11900,
+        "price": 14000,
     },
     "cr diamond pass": {
         "display": "💠 **Clash Royale Diamond Pass**",
         "desc": "Unlock the Diamond Pass for exclusive perks!",
-        "price": 20400,
+        "price": 24000,
     },
     "nitro": {
         "display": "🤖 **Discord Nitro**",
         "desc": "Get Discord Nitro for 1 month!",
-        "price": 17000,
+        "price": 20000,
     },
     "paypal": {
         "display": "💵 **15 USD PayPal**",
         "desc": "Redeem 15 USD via PayPal!",
-        "price": 25500,
+        "price": 30000,
     },
     "shoutout": {
         "display": "📣 **Shoutout**",
         "desc": "Get a personal shoutout in announcements!",
-        "price": 12000,
+        "price": 14000,
     },
 }
 

--- a/features/economy.py
+++ b/features/economy.py
@@ -58,8 +58,8 @@ DEFAULT_MONTHLY_BUDGET = 50.0
 
 # Dollar impact for rewards that consume the monthly redemption budget.
 REDEMPTION_BUDGET_COSTS = {
-    "brawl pass": 10.0,
-    "brawl pass+": 15.0,
+    "brawl pass": 9.0,
+    "brawl pass+": 13.0,
     "coc gold pass": 7.0,
     "cr diamond pass": 12.0,
     "nitro": 10.0,

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -41,11 +41,11 @@ def test_budget_month_key_matches_current_month():
 
 
 def test_budget_cost_brawl_pass():
-    assert _budget_cost_for_item("brawl pass") == 10.0
+    assert _budget_cost_for_item("brawl pass") == 9.0
 
 
 def test_budget_cost_brawl_pass_plus():
-    assert _budget_cost_for_item("brawl pass+") == 15.0
+    assert _budget_cost_for_item("brawl pass+") == 13.0
 
 
 def test_budget_cost_nitro():
@@ -61,7 +61,7 @@ def test_budget_cost_shoutout_is_free():
 
 
 def test_budget_cost_case_insensitive():
-    assert _budget_cost_for_item("Brawl Pass") == 10.0
+    assert _budget_cost_for_item("Brawl Pass") == 9.0
     assert _budget_cost_for_item("NITRO") == 10.0
 
 
@@ -252,7 +252,7 @@ def test_pending_total_falls_back_to_item_cost():
             "redemption-opener:2|item:paypal|budget_usd:notanumber",
         ]
     )
-    assert _pending_redemptions_total(guild) == (25.0, 2)
+    assert _pending_redemptions_total(guild) == (24.0, 2)
 
 
 def test_pending_total_ignores_zero_cost_tickets():
@@ -335,7 +335,7 @@ async def test_queue_processing_skips_unaffordable_entry(monkeypatch):
     cog, _ = _make_economy_cog(category)
     entries = [
         {"_id": "a1", "user_id": "1", "item": "paypal"},  # $15 > $12 available
-        {"_id": "a2", "user_id": "2", "item": "brawl pass"},  # $10 fits
+        {"_id": "a2", "user_id": "2", "item": "brawl pass"},  # $9 fits
     ]
     create_ticket, remove_entry, _ = _patch_queue_helpers(
         monkeypatch, entries, budgets=[12.0, 12.0]


### PR DESCRIPTION
### Changes
* Updated `SHOP_DATA` token prices in `features/config.py` to a 2,000 tokens/$ ratio
* Corrected stale Brawl Pass USD costs in `REDEMPTION_BUDGET_COSTS` ($10→$9, $15→$13)
* Synced docs and tests to the corrected values

### Notes
* USD costs actually live in `REDEMPTION_BUDGET_COSTS` (economy.py), not `SHOP_DATA` as the ticket stated

Closes #366
