### PR TITLE
374-Enhancement add auto Hall of Fame post to endtourney

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Every user always has **4 active quests** — one daily and one weekly per categ
 ### Tournament System
 - **Phase Management:**
   - `!starttourney [region]` — start live tournament, reset counters, init queue dashboard. Use `!starttourney SA` for South America mode.
-  - `!endtourney` — end tournament, clean up dashboards and tickets.
+  - `!endtourney` — end tournament, clean up dashboards and tickets, auto-post Hall of Fame.
 - **Ticket Panels:** `/tourney-panel` (live) and `/pre-tourney-panel` (pre-tourney) post interactive open buttons.
 - **Ticket Operations:**
   - `!close` / `!c` — close a ticket.
@@ -154,7 +154,7 @@ Every user always has **4 active quests** — one daily and one weekly per categ
   - `/match-history <team>` — view match history.
   - `/set-ticket-match <team1> <team2>` — assign match context to a ticket.
   - `/tourney-progress` — bracket progress dashboard with semi-final/final announcements.
-- **Hall of Fame:** `/hall-of-fame` — post winning teams with prize distribution.
+- **Hall of Fame:** `/hall-of-fame` — post winning teams with prize distribution; also auto-triggered by `!endtourney` using the session's Matcherino ID.
 - **Blacklist:** `/blacklist add/remove/list` — manage banned users (Discord ID, Matcherino profile, reason, alts).
 - **Rate Limits:** Max 3 open tickets per user, 180s cooldown. Auto-reopen after 6-hour lock.
 - **Auto-translation:** Ticket messages auto-translated via `deep-translator` + `langdetect`.

--- a/docs/TOURNEY_OVERVIEW.md
+++ b/docs/TOURNEY_OVERVIEW.md
@@ -55,12 +55,13 @@ The tournament system orchestrates the full lifecycle of a Brawl Stars tournamen
 7. **Posts the tournament report embed** to the command channel and archives it to `TOURNEY_REPORT_CHANNEL_ID`
 8. **Closes the session** in MongoDB (`end_tourney_session()`) and disables data collection
 9. **Clears the bracket team cache** (`clear_bracket_teams_cache()`)
-10. **Reopens** `OTHER_TICKET_CHANNEL_ID` (unlocks members)
-11. **Restores Admin role name** to its original value
-12. **Cancels the slowmode timer** and removes slowmode from general channel immediately
-13. **Unlocks Spanish channel** (`SPANISH_CHANNEL_ID`)
-14. **Main tourney support channel**: hides from `@everyone`, purges, renames to `「❌❌❌」「🔴」tourney-support`
-15. **Pre-tourney support channel**: re-opens for viewing (not sending), purges, posts pre-tourney panel, renames to `「🟡」pre-tourney-support`
+10. **Auto-posts Hall of Fame** using the session's `matcherino_id` (shared `post_hall_of_fame()` helper, also used by `/hall-of-fame`) — skipped if no `matcherino_id` was set; failures are caught and reported without blocking the rest of `!endtourney`
+11. **Reopens** `OTHER_TICKET_CHANNEL_ID` (unlocks members)
+12. **Restores Admin role name** to its original value
+13. **Cancels the slowmode timer** and removes slowmode from general channel immediately
+14. **Unlocks Spanish channel** (`SPANISH_CHANNEL_ID`)
+15. **Main tourney support channel**: hides from `@everyone`, purges, renames to `「❌❌❌」「🔴」tourney-support`
+16. **Pre-tourney support channel**: re-opens for viewing (not sending), purges, posts pre-tourney panel, renames to `「🟡」pre-tourney-support`
 
 ---
 

--- a/features/tourney/tourney_commands.py
+++ b/features/tourney/tourney_commands.py
@@ -1865,6 +1865,21 @@ def setup_tourney_commands(bot: commands.Bot):
             await end_tourney_session(session["_id"])
             await set_tourney_collect_data(session["_id"], False)
             clear_bracket_teams_cache()
+
+            # 7. Auto-post Hall of Fame using this tournament's Matcherino ID
+            if matcherino_id:
+                try:
+                    hof_success, hof_message = await post_hall_of_fame(
+                        guild, str(matcherino_id)
+                    )
+                    await ctx.send(
+                        hof_message if hof_success else f"⚠️ Hall of Fame: {hof_message}"
+                    )
+                except Exception as e:
+                    print(f"⚠️ Could not auto-generate Hall of Fame post: {e}")
+                    await ctx.send(
+                        "⚠️ Hall of Fame auto-generation failed — run `/hall-of-fame` manually."
+                    )
         # ------------------------------
 
         await unlock_command(ctx)
@@ -2194,40 +2209,27 @@ def setup_tourney_commands(bot: commands.Bot):
             f"{user.mention} has been removed from this ticket by {interaction.user.mention}."
         )
 
-    @app_commands.command(
-        name="hall-of-fame",
-        description="Automatically fetch results and post to Hall of Fame.",
-    )
-    @app_commands.describe(tournament_id="The Matcherino ID (e.g. 183089)")
-    async def hall_of_fame(interaction: discord.Interaction, tournament_id: str):
-        if not isinstance(interaction.user, discord.Member) or not is_staff(
-            interaction.user
-        ):
-            await interaction.response.send_message(
-                "❌ Permission denied.", ephemeral=True
-            )
-            return
+    async def post_hall_of_fame(
+        guild: discord.Guild, tournament_id: str
+    ) -> tuple[bool, str]:
+        """Fetch results for tournament_id and post them to the Hall of Fame channel.
 
-        # Get the target channel first to ensure config is correct
-        target_channel = interaction.guild.get_channel(HALL_OF_FAME_CHANNEL_ID)
+        Returns (success, message) instead of talking to a discord.Interaction so it
+        can be called both from the /hall-of-fame slash command and from !endtourney.
+        """
+        target_channel = guild.get_channel(HALL_OF_FAME_CHANNEL_ID)
         if not target_channel or not isinstance(target_channel, discord.TextChannel):
-            await interaction.response.send_message(
+            return (
+                False,
                 f"❌ Could not find Hall of Fame channel (ID: {HALL_OF_FAME_CHANNEL_ID}).",
-                ephemeral=True,
             )
-            return
-
-        await interaction.response.defer()
 
         # Clean ID and fetch data using the new scraper
         clean_id = "".join(filter(str.isdigit, tournament_id))
         data = fetch_payout_report(clean_id)
 
         if "error" in data:
-            await interaction.followup.send(
-                f"❌ **Error:** {data['error']}", ephemeral=True
-            )
-            return
+            return False, f"❌ **Error:** {data['error']}"
 
         # Map variables for the embed
         tourney_name = data["tourney_name"]
@@ -2251,14 +2253,31 @@ def setup_tourney_commands(bot: commands.Bot):
 
         try:
             await target_channel.send(embed=embed)
-            await interaction.followup.send(
-                f"✅ Hall of Fame post sent to {target_channel.mention}!"
-            )
+            return True, f"✅ Hall of Fame post sent to {target_channel.mention}!"
         except discord.Forbidden:
-            await interaction.followup.send(
+            return (
+                False,
                 f"❌ I don't have permission to post in {target_channel.mention}.",
-                ephemeral=True,
             )
+
+    @app_commands.command(
+        name="hall-of-fame",
+        description="Automatically fetch results and post to Hall of Fame.",
+    )
+    @app_commands.describe(tournament_id="The Matcherino ID (e.g. 183089)")
+    async def hall_of_fame(interaction: discord.Interaction, tournament_id: str):
+        if not isinstance(interaction.user, discord.Member) or not is_staff(
+            interaction.user
+        ):
+            await interaction.response.send_message(
+                "❌ Permission denied.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer()
+
+        success, message = await post_hall_of_fame(interaction.guild, tournament_id)
+        await interaction.followup.send(message, ephemeral=not success)
 
     # =========================================================================
     #  PAYOUT COMMANDS


### PR DESCRIPTION
### Changes
* Wired `!endtourney` to auto-trigger Hall of Fame generation using the session's Matcherino ID, extracting the shared logic into a `post_hall_of_fame()` helper reused by `/hall-of-fame`
* Updated `docs/TOURNEY_OVERVIEW.md` and `README.md` to document the new auto-post step

Closes #374
