### PR TITLE
395-Bug fix pin ruff ruleset and CI version for deterministic lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,8 @@ jobs:
           python-version: "3.10"
 
       - name: Install Ruff
-        run: pip install ruff
+        # Pin to match the version used locally so CI and local agree.
+        run: pip install ruff==0.15.15
 
       - name: Check lint
         run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,8 @@ version = "1.11.1"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.ruff.lint]
+# Pin the ruleset explicitly so `ruff check` is deterministic across ruff
+# versions (CI installs ruff unpinned). This is ruff's historical default set.
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
### Changes
* Added `[tool.ruff.lint] select = ["E4", "E7", "E9", "F"]` to `pyproject.toml` so `ruff check` uses a fixed ruleset instead of the installed ruff version's shifting defaults
* Pinned CI ruff to `0.15.15` in `.github/workflows/lint.yml` to match the local version, keeping `ruff check` and `ruff format --check` in agreement

Closes #395