### PR TITLE
404-Enhancement add Event Staff role to sticky command permissions

### DIFF
--- a/docs/STICKY_MESSAGES.md
+++ b/docs/STICKY_MESSAGES.md
@@ -44,6 +44,8 @@ async def on_message(message):
 
 ## `!sticky <message>` Command
 
+Requires the **Administrator** permission or the **Event Staff** role (`EVENT_STAFF_ROLE_ID`).
+
 1. Stores content + any attachment URL in MongoDB (`sticky` collection, keyed by `channel_id`)
 2. Posts the sticky message immediately and saves its message ID
 3. If a sticky already exists in the channel, the old one is deleted first
@@ -61,6 +63,8 @@ async def on_message(message):
 ---
 
 ## `!unsticky` Command
+
+Requires the **Administrator** permission or the **Event Staff** role (`EVENT_STAFF_ROLE_ID`).
 
 1. Fetches the current sticky for the channel from MongoDB
 2. Deletes the sticky message from Discord by `message_id`

--- a/features/sticky.py
+++ b/features/sticky.py
@@ -10,6 +10,7 @@ from database.mongo import (
     set_sticky,
     update_sticky_message_id,
 )
+from features.config import EVENT_STAFF_ROLE_ID
 
 
 DEBOUNCE_SECONDS = 1.5
@@ -19,6 +20,12 @@ class StickyMessages(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self._pending: dict[int, asyncio.Task] = {}
+
+    def _has_permission(self, member: discord.Member) -> bool:
+        return bool(
+            member.guild_permissions.administrator
+            or member.get_role(EVENT_STAFF_ROLE_ID)
+        )
 
     async def _post_sticky(
         self, channel: discord.TextChannel, sticky_doc: dict
@@ -40,9 +47,9 @@ class StickyMessages(commands.Cog):
 
     @commands.command(name="sticky")
     async def sticky(self, ctx: commands.Context):
-        if not ctx.author.guild_permissions.administrator:
+        if not self._has_permission(ctx.author):
             await ctx.send(
-                "❌ You need Administrator permissions to use this command.",
+                "❌ You need Administrator or Event Staff permissions to use this command.",
                 delete_after=5,
             )
             return
@@ -92,9 +99,9 @@ class StickyMessages(commands.Cog):
 
     @commands.command(name="unsticky")
     async def unsticky(self, ctx: commands.Context):
-        if not ctx.author.guild_permissions.administrator:
+        if not self._has_permission(ctx.author):
             await ctx.send(
-                "❌ You need Administrator permissions to use this command.",
+                "❌ You need Administrator or Event Staff permissions to use this command.",
                 delete_after=5,
             )
             return


### PR DESCRIPTION
### Changes
  * Allowed the Event Staff role to use `!sticky` and `!unsticky` in addition to Admins

  Closes #404